### PR TITLE
feat: consolidate header nav into user and settings dropdowns

### DIFF
--- a/apps/web/src/components/HeaderSettingsMenu.tsx
+++ b/apps/web/src/components/HeaderSettingsMenu.tsx
@@ -1,0 +1,62 @@
+import { useRef, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Settings } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
+
+interface Props { householdId?: string }
+
+export default function HeaderSettingsMenu({ householdId }: Props) {
+  const { user } = useAuth()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  if (!user) return null
+  const showHousehold = Boolean(householdId)
+  const showAdmin = user.role === 'SYSTEM_ADMIN'
+  if (!showHousehold && !showAdmin) return null
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center focus:outline-none"
+        aria-label="Settings menu"
+      >
+        <Settings size={20} className="text-gray-400 hover:text-white transition-colors" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-56 bg-gray-900 border border-gray-800 rounded-xl shadow-lg z-50 overflow-hidden">
+          <div className="py-1">
+            {showHousehold && (
+              <Link
+                to={`/households/${householdId}/settings`}
+                onClick={() => setOpen(false)}
+                className="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 hover:text-white transition-colors"
+              >
+                Household Settings
+              </Link>
+            )}
+            {showAdmin && (
+              <Link
+                to="/admin/users"
+                onClick={() => setOpen(false)}
+                className="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 hover:text-white transition-colors"
+              >
+                Admin Panel
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/HeaderUserMenu.tsx
+++ b/apps/web/src/components/HeaderUserMenu.tsx
@@ -40,7 +40,7 @@ export default function HeaderUserMenu() {
               onClick={() => setOpen(false)}
               className="block px-4 py-2 text-sm text-gray-300 hover:bg-gray-800 hover:text-white transition-colors"
             >
-              My Income
+              Personal Income
             </Link>
             <Link
               to="/profile"

--- a/apps/web/src/layouts/GlobalLayout.tsx
+++ b/apps/web/src/layouts/GlobalLayout.tsx
@@ -1,13 +1,12 @@
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useHousehold } from '../contexts/HouseholdContext'
-import { useAuth } from '../contexts/AuthContext'
 import { AppFooter } from '../components/AppFooter'
 import HeaderUserMenu from '../components/HeaderUserMenu'
+import HeaderSettingsMenu from '../components/HeaderSettingsMenu'
 import { ChevronLeft } from 'lucide-react'
 
 export function GlobalLayout() {
   const { activeHouseholdId } = useHousehold()
-  const { user } = useAuth()
   const location = useLocation()
   const isDashboard = location.pathname === '/'
 
@@ -32,14 +31,7 @@ export function GlobalLayout() {
           )}
         </div>
         <div className="flex items-center gap-4">
-          <Link to="/income" className="text-sm text-gray-400 hover:text-white transition-colors">
-            My Income
-          </Link>
-          {user?.role === 'SYSTEM_ADMIN' && (
-            <Link to="/admin/users" className="text-sm text-gray-400 hover:text-white transition-colors">
-              Admin
-            </Link>
-          )}
+          <HeaderSettingsMenu />
           <HeaderUserMenu />
         </div>
       </header>

--- a/apps/web/src/layouts/HouseholdLayout.tsx
+++ b/apps/web/src/layouts/HouseholdLayout.tsx
@@ -4,10 +4,10 @@ import {
   LayoutDashboard, TrendingUp, PiggyBank, Receipt, Tag,
   Calendar, Clock, BarChart2, Settings, Menu, X,
 } from 'lucide-react'
-import { useAuth } from '../contexts/AuthContext'
 import { useHousehold } from '../contexts/HouseholdContext'
 import { AppFooter } from '../components/AppFooter'
 import HeaderUserMenu from '../components/HeaderUserMenu'
+import HeaderSettingsMenu from '../components/HeaderSettingsMenu'
 import HouseholdSwitcher from '../components/HouseholdSwitcher'
 
 const NAV_ITEMS = [
@@ -24,7 +24,6 @@ const NAV_ITEMS = [
 export function HouseholdLayout() {
   const { id: householdId } = useParams<{ id: string }>()
   const location = useLocation()
-  const { user } = useAuth()
   const { setActiveHousehold } = useHousehold()
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
@@ -113,17 +112,7 @@ export function HouseholdLayout() {
           <HouseholdSwitcher currentHouseholdId={householdId!} />
         </div>
         <div className="flex items-center gap-5">
-          <Link to="/" className="text-sm text-gray-400 hover:text-white transition-colors">
-            Dashboard
-          </Link>
-          <Link to="/income" className="text-sm text-gray-400 hover:text-white transition-colors">
-            Personal Income
-          </Link>
-          {user?.role === 'SYSTEM_ADMIN' && (
-            <Link to="/admin/users" className="text-sm text-gray-400 hover:text-white transition-colors">
-              Admin
-            </Link>
-          )}
+          <HeaderSettingsMenu householdId={householdId} />
           <HeaderUserMenu />
         </div>
       </header>


### PR DESCRIPTION
Removes scattered loose links from header (Dashboard, Personal Income,
Admin) and organises everything into two clean dropdowns:
- HeaderSettingsMenu (gear icon): Household Settings + Admin Panel
- HeaderUserMenu (avatar): Personal Income, Profile, Change Password, Sign out

https://claude.ai/code/session_01CeJUjhSbRiprB6DrK141dy