### PR TITLE
feat: accounts — track which account expenses and savings are drawn from (#107)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,6 +18,7 @@ import { compareRoutes } from './routes/compare'
 import { savingsRoutes } from './routes/savings'
 import { currencyRoutes } from './routes/currencies'
 import { profileRoutes } from './routes/profile'
+import { accountRoutes } from './routes/accounts'
 import { syncRates, BASE_CURRENCY } from './lib/currency'
 import { prisma } from './lib/prisma'
 
@@ -50,6 +51,7 @@ app.register(authRoutes)
 app.register(userRoutes)
 app.register(householdRoutes)
 app.register(categoryRoutes)
+app.register(accountRoutes)
 app.register(budgetYearRoutes)
 app.register(expenseRoutes)
 app.register(jobRoutes)

--- a/apps/api/src/routes/accounts.ts
+++ b/apps/api/src/routes/accounts.ts
@@ -1,0 +1,241 @@
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { prisma } from '../lib/prisma'
+import { authenticate } from '../plugins/authenticate'
+import { assertBudgetYearAccess } from '../lib/ownership'
+
+const AccountTypeEnum = z.enum(['BANK', 'CREDIT_CARD', 'MOBILE_PAY'])
+
+const CreateAccountSchema = z.object({
+  name: z.string().min(1).max(100),
+  type: AccountTypeEnum,
+})
+
+const UpdateAccountSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  type: AccountTypeEnum.optional(),
+  isActive: z.boolean().optional(),
+}).refine((d) => Object.keys(d).length > 0, { message: 'At least one field is required' })
+
+const accountInclude = {
+  _count: { select: { expenses: true, savingsEntries: true } },
+} as const
+
+async function getHouseholdMembership(householdId: string, userId: string) {
+  return prisma.householdMember.findUnique({
+    where: { householdId_userId: { householdId, userId } },
+  })
+}
+
+export async function accountRoutes(fastify: FastifyInstance) {
+  // ── Personal accounts ─────────────────────────────────────────────────────
+
+  // GET /users/me/accounts
+  fastify.get('/users/me/accounts', { preHandler: authenticate }, async (request, reply) => {
+    const { sub: userId } = request.user
+
+    const accounts = await prisma.account.findMany({
+      where: { ownedByUserId: userId },
+      include: accountInclude,
+      orderBy: { name: 'asc' },
+    })
+
+    return reply.send(accounts)
+  })
+
+  // POST /users/me/accounts
+  fastify.post('/users/me/accounts', { preHandler: authenticate }, async (request, reply) => {
+    const { sub: userId } = request.user
+
+    const result = CreateAccountSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const account = await prisma.account.create({
+      data: {
+        name: result.data.name,
+        type: result.data.type,
+        ownedByUserId: userId,
+        householdId: null,
+      },
+      include: accountInclude,
+    })
+
+    return reply.status(201).send(account)
+  })
+
+  // PUT /users/me/accounts/:id
+  fastify.put('/users/me/accounts/:id', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId } = request.user
+
+    const existing = await prisma.account.findUnique({ where: { id } })
+    if (!existing || existing.ownedByUserId !== userId) {
+      return reply.status(404).send({ error: 'Account not found' })
+    }
+
+    const result = UpdateAccountSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const account = await prisma.account.update({
+      where: { id },
+      data: result.data,
+      include: accountInclude,
+    })
+
+    return reply.send(account)
+  })
+
+  // DELETE /users/me/accounts/:id
+  fastify.delete('/users/me/accounts/:id', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId } = request.user
+
+    const existing = await prisma.account.findUnique({ where: { id }, include: accountInclude })
+    if (!existing || existing.ownedByUserId !== userId) {
+      return reply.status(404).send({ error: 'Account not found' })
+    }
+
+    if (existing._count.expenses > 0 || existing._count.savingsEntries > 0) {
+      return reply.status(409).send({ error: 'This account has associated entries. Remove them before deleting.' })
+    }
+
+    await prisma.account.delete({ where: { id } })
+
+    return reply.status(204).send()
+  })
+
+  // ── Household accounts ────────────────────────────────────────────────────
+
+  // GET /households/:id/accounts — any member
+  fastify.get('/households/:id/accounts', { preHandler: authenticate }, async (request, reply) => {
+    const { id: householdId } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const membership = await getHouseholdMembership(householdId, userId)
+    if (!membership && role !== 'SYSTEM_ADMIN') {
+      return reply.status(403).send({ error: 'Forbidden' })
+    }
+
+    const accounts = await prisma.account.findMany({
+      where: { householdId },
+      include: accountInclude,
+      orderBy: { name: 'asc' },
+    })
+
+    return reply.send(accounts)
+  })
+
+  // POST /households/:id/accounts — admin only
+  fastify.post('/households/:id/accounts', { preHandler: authenticate }, async (request, reply) => {
+    const { id: householdId } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const membership = await getHouseholdMembership(householdId, userId)
+    if (membership?.role !== 'ADMIN' && role !== 'SYSTEM_ADMIN') {
+      return reply.status(403).send({ error: 'Forbidden' })
+    }
+
+    const result = CreateAccountSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const account = await prisma.account.create({
+      data: {
+        name: result.data.name,
+        type: result.data.type,
+        householdId,
+        ownedByUserId: null,
+      },
+      include: accountInclude,
+    })
+
+    return reply.status(201).send(account)
+  })
+
+  // PUT /households/:id/accounts/:accountId — admin only
+  fastify.put('/households/:id/accounts/:accountId', { preHandler: authenticate }, async (request, reply) => {
+    const { id: householdId, accountId } = request.params as { id: string; accountId: string }
+    const { sub: userId, role } = request.user
+
+    const membership = await getHouseholdMembership(householdId, userId)
+    if (membership?.role !== 'ADMIN' && role !== 'SYSTEM_ADMIN') {
+      return reply.status(403).send({ error: 'Forbidden' })
+    }
+
+    const existing = await prisma.account.findUnique({ where: { id: accountId } })
+    if (!existing || existing.householdId !== householdId) {
+      return reply.status(404).send({ error: 'Account not found' })
+    }
+
+    const result = UpdateAccountSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const account = await prisma.account.update({
+      where: { id: accountId },
+      data: result.data,
+      include: accountInclude,
+    })
+
+    return reply.send(account)
+  })
+
+  // DELETE /households/:id/accounts/:accountId — admin only
+  fastify.delete('/households/:id/accounts/:accountId', { preHandler: authenticate }, async (request, reply) => {
+    const { id: householdId, accountId } = request.params as { id: string; accountId: string }
+    const { sub: userId, role } = request.user
+
+    const membership = await getHouseholdMembership(householdId, userId)
+    if (membership?.role !== 'ADMIN' && role !== 'SYSTEM_ADMIN') {
+      return reply.status(403).send({ error: 'Forbidden' })
+    }
+
+    const existing = await prisma.account.findUnique({ where: { id: accountId }, include: accountInclude })
+    if (!existing || existing.householdId !== householdId) {
+      return reply.status(404).send({ error: 'Account not found' })
+    }
+
+    if (existing._count.expenses > 0 || existing._count.savingsEntries > 0) {
+      return reply.status(409).send({ error: 'This account has associated entries. Remove them before deleting.' })
+    }
+
+    await prisma.account.delete({ where: { id: accountId } })
+
+    return reply.status(204).send()
+  })
+
+  // ── Combined endpoint for forms ───────────────────────────────────────────
+
+  // GET /budget-years/:id/accounts
+  // Returns { personal: Account[], household: Account[] } for the expense/savings form dropdown.
+  // personal = accounts owned by the calling user
+  // household = accounts owned by the household that owns this budget year
+  fastify.get('/budget-years/:id/accounts', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+
+    const [personal, household] = await Promise.all([
+      prisma.account.findMany({
+        where: { ownedByUserId: userId, isActive: true },
+        orderBy: { name: 'asc' },
+        select: { id: true, name: true, type: true, isActive: true },
+      }),
+      prisma.account.findMany({
+        where: { householdId: budgetYear.householdId, isActive: true },
+        orderBy: { name: 'asc' },
+        select: { id: true, name: true, type: true, isActive: true },
+      }),
+    ])
+
+    return reply.send({ personal, household })
+  })
+}

--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -210,6 +210,7 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
         category: { select: { id: true, name: true, icon: true } },
         ownedBy: { select: { id: true, name: true } },
         customSplits: true,
+        account: { select: { id: true, name: true, type: true } },
       },
       orderBy: [{ category: { name: 'asc' } }, { label: 'asc' }],
     })
@@ -227,6 +228,22 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
     const byCategory = [...byCategoryMap.values()]
       .sort((a, b) => b.totalMonthly - a.totalMonthly)
       .map((c) => ({ ...c, totalMonthly: c.totalMonthly.toFixed(2) }))
+
+    const byAccountMap = new Map<string, { accountId: string; accountName: string; accountType: string; totalMonthly: number }>()
+    for (const e of expenses) {
+      if (!e.accountId || !e.account) continue
+      const existing = byAccountMap.get(e.accountId) ?? {
+        accountId: e.accountId,
+        accountName: e.account.name,
+        accountType: e.account.type,
+        totalMonthly: 0,
+      }
+      existing.totalMonthly += toNum(e.monthlyEquivalent)
+      byAccountMap.set(e.accountId, existing)
+    }
+    const byAccount = [...byAccountMap.values()]
+      .sort((a, b) => b.totalMonthly - a.totalMonthly)
+      .map((a) => ({ ...a, totalMonthly: a.totalMonthly.toFixed(2) }))
 
     // ── Savings ──────────────────────────────────────────────────────────────
     const savingsEntries = await prisma.savingsEntry.findMany({
@@ -288,6 +305,7 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
           customSplits: e.customSplits,
         })),
         byCategory,
+        byAccount,
       },
       savings: { totalMonthly: totalMonthlySavings.toFixed(2) },
       surplus: surplus.toFixed(2),

--- a/apps/api/src/routes/expenses.ts
+++ b/apps/api/src/routes/expenses.ts
@@ -28,6 +28,7 @@ const ExpenseBaseSchema = z.object({
   ownership: z.enum(['SHARED', 'INDIVIDUAL', 'CUSTOM']).default('SHARED'),
   ownedByUserId: z.string().nullable().optional(),
   customSplits: z.array(CustomSplitSchema).optional(),
+  accountId: z.string().nullable().optional(),
 })
 
 const monthRangeRefinement = (d: { startMonth?: number | null; endMonth?: number | null }) => {
@@ -47,6 +48,7 @@ const expenseInclude = {
   category: { select: { id: true, name: true, icon: true, isSystemWide: true, categoryType: true } },
   ownedBy: { select: { id: true, name: true } },
   customSplits: { include: { user: { select: { id: true, name: true } } } },
+  account: { select: { id: true, name: true, type: true } },
 } as const
 
 
@@ -81,10 +83,17 @@ export async function expenseRoutes(fastify: FastifyInstance) {
     const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
     if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
 
-    const { label, amount, frequency, categoryId, frequencyPeriod, startMonth, endMonth, notes, currencyCode, ownership, ownedByUserId, customSplits } = result.data
+    const { label, amount, frequency, categoryId, frequencyPeriod, startMonth, endMonth, notes, currencyCode, ownership, ownedByUserId, customSplits, accountId } = result.data
 
     const category = await prisma.category.findUnique({ where: { id: categoryId } })
     if (!category) return reply.status(400).send({ error: 'Category not found' })
+
+    if (accountId) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
+    }
 
     const ownershipError = await validateOwnership(ownership, ownedByUserId, customSplits, budgetYear.householdId)
     if (ownershipError) return reply.status(400).send({ error: ownershipError })
@@ -118,6 +127,7 @@ export async function expenseRoutes(fastify: FastifyInstance) {
           rateUsed: currency !== BASE_CURRENCY ? new Decimal(rate) : null,
           ownership,
           ownedByUserId: ownership === 'INDIVIDUAL' ? (ownedByUserId ?? null) : null,
+          accountId: accountId ?? null,
         },
         include: expenseInclude,
       })
@@ -157,11 +167,18 @@ export async function expenseRoutes(fastify: FastifyInstance) {
       return reply.status(404).send({ error: 'Expense not found' })
     }
 
-    const { amount, frequency, categoryId, currencyCode, ownership, ownedByUserId, customSplits, startMonth, endMonth, ...rest } = result.data
+    const { amount, frequency, categoryId, currencyCode, ownership, ownedByUserId, customSplits, startMonth, endMonth, accountId, ...rest } = result.data
 
     if (categoryId) {
       const category = await prisma.category.findUnique({ where: { id: categoryId } })
       if (!category) return reply.status(400).send({ error: 'Category not found' })
+    }
+
+    if (accountId) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
     }
 
     const newOwnership = ownership ?? existing.ownership
@@ -219,6 +236,7 @@ export async function expenseRoutes(fastify: FastifyInstance) {
           currencyCode: newCurrency !== BASE_CURRENCY ? newCurrency : null,
           originalAmount: newCurrency !== BASE_CURRENCY ? new Decimal(newAmount) : null,
           rateUsed: newCurrency !== BASE_CURRENCY ? new Decimal(rate) : null,
+          ...(accountId !== undefined && { accountId: accountId ?? null }),
         },
         include: expenseInclude,
       })

--- a/apps/api/src/routes/savings.ts
+++ b/apps/api/src/routes/savings.ts
@@ -28,6 +28,7 @@ const CreateSavingsSchema = z.object({
   ownedByUserId: z.string().nullable().optional(),
   categoryId: z.string().optional(),
   customSplits: z.array(CustomSplitSchema).optional(),
+  accountId: z.string().nullable().optional(),
 })
 
 const UpdateSavingsSchema = CreateSavingsSchema.partial().refine(
@@ -39,6 +40,7 @@ const savingsInclude = {
   category: { select: { id: true, name: true, icon: true, categoryType: true } },
   ownedBy: { select: { id: true, name: true } },
   customSplits: { include: { user: { select: { id: true, name: true } } } },
+  account: { select: { id: true, name: true, type: true } },
 } as const
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -75,7 +77,14 @@ export async function savingsRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { label, amount, frequency, notes, currencyCode, ownership, ownedByUserId, categoryId, customSplits } = result.data
+    const { label, amount, frequency, notes, currencyCode, ownership, ownedByUserId, categoryId, customSplits, accountId } = result.data
+
+    if (accountId) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
+    }
 
     const ownershipError = await validateOwnership(ownership, ownedByUserId, customSplits, budgetYear.householdId)
     if (ownershipError) return reply.status(400).send({ error: ownershipError })
@@ -102,6 +111,7 @@ export async function savingsRoutes(fastify: FastifyInstance) {
           ownership,
           ownedByUserId: ownership === 'INDIVIDUAL' ? (ownedByUserId ?? null) : null,
           categoryId: categoryId ?? null,
+          accountId: accountId ?? null,
         },
         include: savingsInclude,
       })
@@ -140,7 +150,14 @@ export async function savingsRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { ownership, ownedByUserId, categoryId, customSplits, ...data } = result.data
+    const { ownership, ownedByUserId, categoryId, customSplits, accountId, ...data } = result.data
+
+    if (accountId) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
+    }
 
     const newOwnership = ownership ?? existing.ownership
     const newOwnedByUserId = ownedByUserId !== undefined ? ownedByUserId : existing.ownedByUserId
@@ -189,6 +206,7 @@ export async function savingsRoutes(fastify: FastifyInstance) {
           ownership: newOwnership,
           ownedByUserId: newOwnership === 'INDIVIDUAL' ? (newOwnedByUserId ?? null) : null,
           ...(categoryId !== undefined && { categoryId: categoryId ?? null }),
+          ...(accountId !== undefined && { accountId: accountId ?? null }),
         },
         include: savingsInclude,
       })

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -51,6 +51,13 @@ interface ExpenseByCategory {
   totalMonthly: string
 }
 
+interface ExpenseByAccount {
+  accountId: string
+  accountName: string
+  accountType: string
+  totalMonthly: string
+}
+
 interface MemberSplit {
   userId: string
   name: string
@@ -72,7 +79,7 @@ interface Warnings {
 interface DashboardSummary {
   budgetYear: BudgetYear | null
   income: { totalMonthly: string; members: IncomeMember[] }
-  expenses: { totalMonthly: string; items: ExpenseItem[]; byCategory: ExpenseByCategory[] }
+  expenses: { totalMonthly: string; items: ExpenseItem[]; byCategory: ExpenseByCategory[]; byAccount: ExpenseByAccount[] }
   savings: { totalMonthly: string }
   surplus: string
   memberSplits: MemberSplit[]
@@ -476,6 +483,35 @@ export function DashboardPage() {
                         />
                       </div>
                       <span className="text-gray-400 text-sm tabular-nums w-20 text-right">{fmt(c.totalMonthly)}</span>
+                      <span className="text-gray-600 text-xs w-10 text-right">{pct.toFixed(0)}%</span>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {summary.expenses.byAccount?.length > 0 && (
+            <div className="mb-8">
+              <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">By account</h2>
+              <div className="space-y-2">
+                {summary.expenses.byAccount.map((a) => {
+                  const pct = expenses > 0 ? (parseFloat(a.totalMonthly) / expenses) * 100 : 0
+                  return (
+                    <div key={a.accountId} className="flex items-center gap-3">
+                      <span className="text-gray-300 text-sm w-36 shrink-0 truncate flex items-center gap-1.5">
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-gray-800 text-gray-500 shrink-0">
+                          {a.accountType.replace('_', ' ')}
+                        </span>
+                        {a.accountName}
+                      </span>
+                      <div className="flex-1 bg-gray-800 rounded-full h-2">
+                        <div
+                          className="bg-blue-400/70 h-2 rounded-full transition-all"
+                          style={{ width: `${Math.min(pct, 100)}%` }}
+                        />
+                      </div>
+                      <span className="text-gray-400 text-sm tabular-nums w-20 text-right">{fmt(a.totalMonthly)}</span>
                       <span className="text-gray-600 text-xs w-10 text-right">{pct.toFixed(0)}%</span>
                     </div>
                   )

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -35,6 +35,25 @@ interface HouseholdMember {
   user: { id: string; name: string }
 }
 
+type AccountType = 'BANK' | 'CREDIT_CARD' | 'MOBILE_PAY'
+
+interface AccountInfo {
+  id: string
+  name: string
+  type: AccountType
+}
+
+interface AccountGroups {
+  personal: AccountInfo[]
+  household: AccountInfo[]
+}
+
+const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  BANK: 'Bank',
+  CREDIT_CARD: 'Credit card',
+  MOBILE_PAY: 'Mobile pay',
+}
+
 interface Expense {
   id: string
   label: string
@@ -53,6 +72,8 @@ interface Expense {
   ownedByUserId: string | null
   ownedBy: { id: string; name: string } | null
   customSplits: { userId: string; user: { id: string; name: string }; pct: string }[]
+  accountId: string | null
+  account: AccountInfo | null
 }
 
 interface Currency {
@@ -102,6 +123,7 @@ interface ExpenseForm {
   ownership: ExpenseOwnership
   ownedByUserId: string | null
   customSplits: CustomSplitInput[]
+  accountId: string | null
 }
 
 const MONTH_OPTIONS = [
@@ -128,6 +150,7 @@ const emptyForm = (baseCurrency: string): ExpenseForm => ({
   label: '', amount: '', frequency: 'MONTHLY', categoryId: '', frequencyPeriod: '',
   startMonth: '', endMonth: '', notes: '',
   currencyCode: baseCurrency, ownership: 'SHARED', ownedByUserId: null, customSplits: [],
+  accountId: null,
 })
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -149,6 +172,7 @@ export function ExpensesPage() {
   const [sortKey, setSortKey] = useState<SortKey>('category')
   const [sortAsc, setSortAsc] = useState(true)
   const [filterCategories, setFilterCategories] = useState<Set<string>>(new Set())
+  const [filterAccounts, setFilterAccounts] = useState<Set<string>>(new Set())
   const [view, setView] = useState<'list' | 'calendar'>('list')
 
   // Modal state
@@ -200,13 +224,29 @@ export function ExpensesPage() {
   })
   const members = householdData?.members ?? []
 
+  const { data: accountGroups } = useQuery<AccountGroups>({
+    queryKey: ['accounts-for-budget-year', activeBudgetYear?.id],
+    queryFn: async () => (await api.get<AccountGroups>(`/budget-years/${activeBudgetYear!.id}/accounts`)).data,
+    enabled: !!activeBudgetYear,
+  })
+  const personalAccounts = accountGroups?.personal ?? []
+  const householdAccountOptions = accountGroups?.household ?? []
+  const hasAccounts = personalAccounts.length > 0 || householdAccountOptions.length > 0
 
   // ── Derived data ─────────────────────────────────────────────────────────────
 
+  const accountsInExpenses = useMemo(() => {
+    const map = new Map<string, AccountInfo>()
+    for (const e of expenses) {
+      if (e.account) map.set(e.account.id, e.account)
+    }
+    return [...map.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }, [expenses])
+
   const filtered = useMemo(() => {
-    let list = filterCategories.size > 0
-      ? expenses.filter((e) => filterCategories.has(e.category.id))
-      : expenses
+    let list = expenses
+    if (filterCategories.size > 0) list = list.filter((e) => filterCategories.has(e.category.id))
+    if (filterAccounts.size > 0) list = list.filter((e) => e.accountId != null && filterAccounts.has(e.accountId))
 
     return [...list].sort((a, b) => {
       let cmp = 0
@@ -253,6 +293,7 @@ export function ExpensesPage() {
         customSplits: data.ownership === 'CUSTOM'
           ? data.customSplits.map((s) => ({ userId: s.userId, pct: parseFloat(s.pct) }))
           : undefined,
+        accountId: data.accountId || null,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', activeBudgetYear?.id] })
@@ -279,6 +320,7 @@ export function ExpensesPage() {
         customSplits: data.ownership === 'CUSTOM'
           ? data.customSplits.map((s) => ({ userId: s.userId, pct: parseFloat(s.pct) }))
           : undefined,
+        accountId: data.accountId || null,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', activeBudgetYear?.id] })
@@ -326,6 +368,7 @@ export function ExpensesPage() {
       ownership: expense.ownership ?? 'SHARED',
       ownedByUserId: expense.ownedByUserId ?? null,
       customSplits: expense.customSplits?.map((s) => ({ userId: s.userId, pct: s.pct })) ?? [],
+      accountId: expense.account?.id ?? null,
     })
     setFormError('')
     setEditingExpense(expense)
@@ -417,6 +460,34 @@ export function ExpensesPage() {
           <>
             {/* Controls */}
             <div className="flex flex-col gap-3 mb-4">
+              {accountsInExpenses.length > 0 && (
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-xs text-gray-500 mr-1">Account:</span>
+                  {accountsInExpenses.map((a) => (
+                    <button
+                      key={a.id}
+                      onClick={() => setFilterAccounts((prev) => {
+                        const next = new Set(prev)
+                        if (next.has(a.id)) next.delete(a.id); else next.add(a.id)
+                        return next
+                      })}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        filterAccounts.has(a.id)
+                          ? 'bg-amber-400 border-amber-400 text-gray-950 font-medium'
+                          : 'bg-gray-800 border-gray-700 text-gray-400 hover:text-white'
+                      }`}
+                    >
+                      {a.name}
+                      <span className="ml-1 opacity-60">{ACCOUNT_TYPE_LABELS[a.type]}</span>
+                    </button>
+                  ))}
+                  {filterAccounts.size > 0 && (
+                    <button onClick={() => setFilterAccounts(new Set())} className="text-xs text-gray-600 hover:text-gray-400 transition-colors ml-1">
+                      Clear
+                    </button>
+                  )}
+                </div>
+              )}
               <div className="flex items-center justify-between gap-4">
                 <CategoryFilter
                   categories={categories}
@@ -518,6 +589,11 @@ export function ExpensesPage() {
                             {e.notes && (
                               <span className="text-gray-600 text-xs" title={e.notes}>📝</span>
                             )}
+                            {e.account && (
+                              <span className="text-xs px-2 py-0.5 rounded-full bg-gray-800 text-gray-400 border border-gray-700">
+                                {e.account.name}
+                              </span>
+                            )}
                           </div>
                         </td>
                         <td className="px-4 py-3 text-gray-300">
@@ -565,7 +641,7 @@ export function ExpensesPage() {
                   <tfoot>
                     <tr className="border-t border-gray-700 bg-gray-800/50">
                       <td colSpan={4} className="px-4 py-3 text-sm text-gray-400 font-medium">
-                        Total{filterCategories.size > 0 ? ' (filtered)' : ''} — {filtered.length} {filtered.length === 1 ? 'expense' : 'expenses'}
+                        Total{(filterCategories.size > 0 || filterAccounts.size > 0) ? ' (filtered)' : ''} — {filtered.length} {filtered.length === 1 ? 'expense' : 'expenses'}
                       </td>
                       <td className="px-4 py-3 text-right text-amber-400 font-bold tabular-nums">
                         {fmt(totalMonthly)}
@@ -671,6 +747,34 @@ export function ExpensesPage() {
                   ))}
                 </select>
               </div>
+              {hasAccounts && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-400 mb-1">
+                    Account <span className="text-gray-600">(optional)</span>
+                  </label>
+                  <select
+                    value={form.accountId ?? ''}
+                    onChange={(e) => setForm({ ...form, accountId: e.target.value || null })}
+                    className={inputClass}
+                  >
+                    <option value="">— None —</option>
+                    {personalAccounts.length > 0 && (
+                      <optgroup label="My accounts">
+                        {personalAccounts.map((a) => (
+                          <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                        ))}
+                      </optgroup>
+                    )}
+                    {householdAccountOptions.length > 0 && (
+                      <optgroup label="Household accounts">
+                        {householdAccountOptions.map((a) => (
+                          <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                </div>
+              )}
               {members.length > 0 && (
                 <>
                   <div>

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -3,6 +3,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { toast } from 'sonner'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { api } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { Modal } from '../components/Modal'
@@ -33,6 +34,27 @@ interface UserOption {
   isProxy?: boolean
 }
 
+type AccountType = 'BANK' | 'CREDIT_CARD' | 'MOBILE_PAY'
+
+interface HouseholdAccount {
+  id: string
+  name: string
+  type: AccountType
+  isActive: boolean
+  _count: { expenses: number; savingsEntries: number }
+}
+
+interface AccountForm {
+  name: string
+  type: AccountType
+}
+
+const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  BANK: 'Bank',
+  CREDIT_CARD: 'Credit card',
+  MOBILE_PAY: 'Mobile pay',
+}
+
 export function HouseholdPage() {
   const { id } = useParams<{ id: string }>()
   const { user: me } = useAuth()
@@ -43,6 +65,14 @@ export function HouseholdPage() {
   const [addUserId, setAddUserId] = useState('')
   const [addRole, setAddRole] = useState<'ADMIN' | 'MEMBER'>('MEMBER')
   const [addError, setAddError] = useState('')
+
+  // Account state
+  const [showAddAccount, setShowAddAccount] = useState(false)
+  const [editingAccount, setEditingAccount] = useState<HouseholdAccount | null>(null)
+  const [deleteAccountTarget, setDeleteAccountTarget] = useState<HouseholdAccount | null>(null)
+  const [accountForm, setAccountForm] = useState<AccountForm>({ name: '', type: 'BANK' })
+  const [accountFormError, setAccountFormError] = useState('')
+  const [accountDeleteError, setAccountDeleteError] = useState('')
 
   const [editingName, setEditingName] = useState(false)
   const [nameValue, setNameValue] = useState('')
@@ -67,6 +97,88 @@ export function HouseholdPage() {
   })
 
   const isAdmin = household?.myRole === 'ADMIN' || me?.role === 'SYSTEM_ADMIN'
+
+  const { data: householdAccounts = [] } = useQuery<HouseholdAccount[]>({
+    queryKey: ['accounts', 'household', id],
+    queryFn: async () => (await api.get<HouseholdAccount[]>(`/households/${id}/accounts`)).data,
+    enabled: !!id,
+  })
+
+  const createAccountMutation = useMutation({
+    mutationFn: (data: AccountForm) => api.post(`/households/${id}/accounts`, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'household', id] })
+      setShowAddAccount(false)
+      setAccountForm({ name: '', type: 'BANK' })
+      setAccountFormError('')
+      toast.success('Account added')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setAccountFormError((err.response?.data as { error?: string })?.error ?? 'Failed to save')
+    },
+  })
+
+  const updateAccountMutation = useMutation({
+    mutationFn: (data: AccountForm) => api.put(`/households/${id}/accounts/${editingAccount!.id}`, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'household', id] })
+      setEditingAccount(null)
+      setAccountFormError('')
+      toast.success('Account updated')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setAccountFormError((err.response?.data as { error?: string })?.error ?? 'Failed to save')
+    },
+  })
+
+  const toggleAccountActiveMutation = useMutation({
+    mutationFn: ({ accountId, isActive }: { accountId: string; isActive: boolean }) =>
+      api.put(`/households/${id}/accounts/${accountId}`, { isActive }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'household', id] })
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        toast.error((err.response?.data as { error?: string })?.error ?? 'Failed to update')
+    },
+  })
+
+  const deleteAccountMutation = useMutation({
+    mutationFn: (accountId: string) => api.delete(`/households/${id}/accounts/${accountId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'household', id] })
+      setDeleteAccountTarget(null)
+      setAccountDeleteError('')
+      toast.success('Account deleted')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setAccountDeleteError((err.response?.data as { error?: string })?.error ?? 'Failed to delete')
+    },
+  })
+
+  function handleAccountSubmit(e: FormEvent) {
+    e.preventDefault()
+    setAccountFormError('')
+    if (!accountForm.name.trim()) { setAccountFormError('Name is required'); return }
+    if (editingAccount) updateAccountMutation.mutate(accountForm)
+    else createAccountMutation.mutate(accountForm)
+  }
+
+  function openEditAccount(account: HouseholdAccount) {
+    setAccountForm({ name: account.name, type: account.type })
+    setAccountFormError('')
+    setEditingAccount(account)
+  }
+
+  function closeAccountModal() {
+    setShowAddAccount(false)
+    setEditingAccount(null)
+    setAccountForm({ name: '', type: 'BANK' })
+    setAccountFormError('')
+  }
 
   // Users not already in this household
   const memberUserIds = new Set(household?.members.map((m) => m.userId) ?? [])
@@ -302,6 +414,81 @@ export function HouseholdPage() {
           </table>
         </div>
 
+        {/* Household accounts */}
+        <div className="mt-10">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Accounts</h2>
+            {isAdmin && (
+              <button
+                onClick={() => { setShowAddAccount(true); setAccountFormError('') }}
+                className="flex items-center gap-1.5 bg-amber-400 hover:bg-amber-300 text-gray-950 font-semibold text-sm px-3 py-1.5 rounded-lg transition-colors"
+              >
+                <Plus size={14} /> Add account
+              </button>
+            )}
+          </div>
+
+          {householdAccounts.length === 0 ? (
+            <p className="text-sm text-gray-500">No household accounts yet.</p>
+          ) : (
+            <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-800 text-gray-400 text-left">
+                    <th className="px-4 py-3 font-medium">Name</th>
+                    <th className="px-4 py-3 font-medium">Type</th>
+                    <th className="px-4 py-3 font-medium">Status</th>
+                    {isAdmin && <th className="px-4 py-3 font-medium sr-only">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {householdAccounts.map((account) => (
+                    <tr key={account.id} className="border-b border-gray-800 last:border-0 hover:bg-gray-800/40">
+                      <td className="px-4 py-3 text-white">
+                        <span className={account.isActive ? 'text-white' : 'text-gray-500 line-through'}>
+                          {account.name}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-gray-800 text-gray-300 border border-gray-700">
+                          {ACCOUNT_TYPE_LABELS[account.type]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-400">
+                        {account.isActive ? 'Active' : 'Inactive'}
+                      </td>
+                      {isAdmin && (
+                        <td className="px-4 py-3 text-right">
+                          <div className="flex items-center justify-end gap-2">
+                            <button
+                              onClick={() => toggleAccountActiveMutation.mutate({ accountId: account.id, isActive: !account.isActive })}
+                              className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                            >
+                              {account.isActive ? 'Deactivate' : 'Activate'}
+                            </button>
+                            <button
+                              onClick={() => openEditAccount(account)}
+                              className="text-gray-500 hover:text-gray-300 transition-colors p-1"
+                            >
+                              <Pencil size={14} />
+                            </button>
+                            <button
+                              onClick={() => { setDeleteAccountTarget(account); setAccountDeleteError('') }}
+                              className="text-gray-500 hover:text-red-400 transition-colors p-1"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          </div>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
         {/* Danger zone */}
         {isAdmin && (
           <div className="mt-12 border border-red-900/50 rounded-xl p-6">
@@ -444,6 +631,94 @@ export function HouseholdPage() {
               Confirm
             </button>
             <button onClick={() => setConfirmRoleChange(null)}
+              className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors">
+              Cancel
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* Add/Edit account modal */}
+      {(showAddAccount || editingAccount) && (
+        <Modal
+          title={editingAccount ? 'Edit account' : 'Add account'}
+          onClose={closeAccountModal}
+          size="sm"
+        >
+          <form onSubmit={handleAccountSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Name</label>
+              <input
+                type="text"
+                value={accountForm.name}
+                onChange={(e) => setAccountForm({ ...accountForm, name: e.target.value })}
+                placeholder="e.g. Shared current account"
+                className={inputClass}
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Type</label>
+              <select
+                value={accountForm.type}
+                onChange={(e) => setAccountForm({ ...accountForm, type: e.target.value as AccountType })}
+                className={inputClass}
+              >
+                {Object.entries(ACCOUNT_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </div>
+            {accountFormError && (
+              <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">
+                {accountFormError}
+              </div>
+            )}
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={createAccountMutation.isPending || updateAccountMutation.isPending}
+                className="flex-1 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                {createAccountMutation.isPending || updateAccountMutation.isPending ? 'Saving…' : editingAccount ? 'Save changes' : 'Add account'}
+              </button>
+              <button type="button" onClick={closeAccountModal}
+                className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors">
+                Cancel
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+
+      {/* Delete account confirmation */}
+      {deleteAccountTarget && (
+        <Modal title="Delete account" onClose={() => { setDeleteAccountTarget(null); setAccountDeleteError('') }} size="sm">
+          <p className="text-gray-300 text-sm mb-2">
+            Delete <span className="font-semibold text-white">"{deleteAccountTarget.name}"</span>?
+          </p>
+          {deleteAccountTarget._count.expenses > 0 || deleteAccountTarget._count.savingsEntries > 0 ? (
+            <p className="text-amber-400 text-xs mb-4">
+              This account has {deleteAccountTarget._count.expenses + deleteAccountTarget._count.savingsEntries} associated entries.
+              Remove them before deleting, or deactivate the account instead.
+            </p>
+          ) : (
+            <p className="text-gray-500 text-xs mb-4">This action cannot be undone.</p>
+          )}
+          {accountDeleteError && (
+            <div className="bg-red-950 border border-red-800 text-red-300 px-3 py-2 rounded-lg text-xs mb-4">
+              {accountDeleteError}
+            </div>
+          )}
+          <div className="flex gap-3">
+            <button
+              onClick={() => deleteAccountMutation.mutate(deleteAccountTarget.id)}
+              disabled={deleteAccountMutation.isPending}
+              className="flex-1 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              {deleteAccountMutation.isPending ? 'Deleting…' : 'Delete'}
+            </button>
+            <button onClick={() => { setDeleteAccountTarget(null); setAccountDeleteError('') }}
               className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors">
               Cancel
             </button>

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -5,10 +5,11 @@ import axios from 'axios'
 import { toast } from 'sonner'
 import { api } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
-import { AlertTriangle, User, Home } from 'lucide-react'
+import { AlertTriangle, User, Home, CreditCard, Plus, Pencil, Trash2 } from 'lucide-react'
 import Avatar from '../components/Avatar'
 import { PageLoader } from '../components/LoadingSpinner'
 import { PageHeader } from '../components/PageHeader'
+import { Modal } from '../components/Modal'
 import { inputClass } from '../lib/styles'
 
 const cardClass = 'bg-gray-900 border border-gray-800 rounded-xl p-6'
@@ -47,6 +48,22 @@ interface Household {
 interface IncomeSummary {
   allocationPct: string
   overAllocated: boolean
+}
+
+type AccountType = 'BANK' | 'CREDIT_CARD' | 'MOBILE_PAY'
+
+interface Account {
+  id: string
+  name: string
+  type: AccountType
+  isActive: boolean
+  _count: { expenses: number; savingsEntries: number }
+}
+
+const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  BANK: 'Bank',
+  CREDIT_CARD: 'Credit card',
+  MOBILE_PAY: 'Mobile pay',
 }
 
 // ── Tab 1: Profile ───────────────────────────────────────────────────────────
@@ -421,13 +438,278 @@ function HouseholdsTab() {
   )
 }
 
+// ── Tab 3: Accounts ──────────────────────────────────────────────────────────
+
+interface AccountForm {
+  name: string
+  type: AccountType
+}
+
+function emptyAccountForm(): AccountForm {
+  return { name: '', type: 'BANK' }
+}
+
+function AccountsTab() {
+  const queryClient = useQueryClient()
+
+  const { data: accounts = [], isLoading } = useQuery<Account[]>({
+    queryKey: ['accounts', 'personal'],
+    queryFn: async () => (await api.get<Account[]>('/users/me/accounts')).data,
+  })
+
+  const [showAdd, setShowAdd] = useState(false)
+  const [editingAccount, setEditingAccount] = useState<Account | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Account | null>(null)
+  const [form, setForm] = useState<AccountForm>(emptyAccountForm())
+  const [formError, setFormError] = useState('')
+  const [deleteError, setDeleteError] = useState('')
+
+  function openAdd() {
+    setForm(emptyAccountForm())
+    setFormError('')
+    setShowAdd(true)
+  }
+
+  function openEdit(account: Account) {
+    setForm({ name: account.name, type: account.type })
+    setFormError('')
+    setEditingAccount(account)
+  }
+
+  function closeModal() {
+    setShowAdd(false)
+    setEditingAccount(null)
+    setForm(emptyAccountForm())
+    setFormError('')
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (data: AccountForm) => api.post('/users/me/accounts', data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'personal'] })
+      closeModal()
+      toast.success('Account added')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setFormError((err.response?.data as { error?: string })?.error ?? 'Failed to save')
+    },
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (data: AccountForm) => api.put(`/users/me/accounts/${editingAccount!.id}`, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'personal'] })
+      closeModal()
+      toast.success('Account updated')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setFormError((err.response?.data as { error?: string })?.error ?? 'Failed to save')
+    },
+  })
+
+  const toggleActiveMutation = useMutation({
+    mutationFn: ({ id, isActive }: { id: string; isActive: boolean }) =>
+      api.put(`/users/me/accounts/${id}`, { isActive }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'personal'] })
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        toast.error((err.response?.data as { error?: string })?.error ?? 'Failed to update')
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/users/me/accounts/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts', 'personal'] })
+      setDeleteTarget(null)
+      setDeleteError('')
+      toast.success('Account deleted')
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setDeleteError((err.response?.data as { error?: string })?.error ?? 'Failed to delete')
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError('')
+    if (!form.name.trim()) { setFormError('Name is required'); return }
+    if (editingAccount) updateMutation.mutate(form)
+    else createMutation.mutate(form)
+  }
+
+  const isMutating = createMutation.isPending || updateMutation.isPending
+
+  return (
+    <div className="space-y-4">
+      <div className={cardClass}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-semibold">Personal accounts</h2>
+          <button
+            onClick={openAdd}
+            className="flex items-center gap-1.5 bg-amber-400 hover:bg-amber-300 text-gray-950 font-semibold rounded-lg px-3 py-1.5 text-sm transition-colors"
+          >
+            <Plus size={14} /> Add account
+          </button>
+        </div>
+
+        {isLoading ? (
+          <PageLoader />
+        ) : accounts.length === 0 ? (
+          <p className="text-sm text-gray-500">No accounts yet. Add one to start tagging expenses and savings.</p>
+        ) : (
+          <div className="space-y-2">
+            {accounts.map((account) => (
+              <div
+                key={account.id}
+                className="flex items-center justify-between bg-gray-800 rounded-lg px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-gray-700 text-gray-300 border border-gray-600">
+                    {ACCOUNT_TYPE_LABELS[account.type]}
+                  </span>
+                  <span className={`text-sm font-medium ${account.isActive ? 'text-white' : 'text-gray-500 line-through'}`}>
+                    {account.name}
+                  </span>
+                  {!account.isActive && (
+                    <span className="text-xs text-gray-600">inactive</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => toggleActiveMutation.mutate({ id: account.id, isActive: !account.isActive })}
+                    className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                  >
+                    {account.isActive ? 'Deactivate' : 'Activate'}
+                  </button>
+                  <button
+                    onClick={() => openEdit(account)}
+                    className="text-gray-500 hover:text-gray-300 transition-colors p-1"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                  <button
+                    onClick={() => { setDeleteTarget(account); setDeleteError('') }}
+                    className="text-gray-500 hover:text-red-400 transition-colors p-1"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add/Edit modal */}
+      {(showAdd || editingAccount) && (
+        <Modal
+          title={editingAccount ? 'Edit account' : 'Add account'}
+          onClose={closeModal}
+          size="sm"
+        >
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Name</label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="e.g. Main bank account"
+                className={inputClass}
+                autoFocus
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Type</label>
+              <select
+                value={form.type}
+                onChange={(e) => setForm({ ...form, type: e.target.value as AccountType })}
+                className={inputClass}
+              >
+                {Object.entries(ACCOUNT_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+            </div>
+            {formError && (
+              <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">
+                {formError}
+              </div>
+            )}
+            <div className="flex gap-3">
+              <button
+                type="submit"
+                disabled={isMutating}
+                className="flex-1 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                {isMutating ? 'Saving…' : editingAccount ? 'Save changes' : 'Add account'}
+              </button>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <Modal title="Delete account" onClose={() => { setDeleteTarget(null); setDeleteError('') }} size="sm">
+          <p className="text-gray-300 text-sm mb-2">
+            Delete <span className="font-semibold text-white">"{deleteTarget.name}"</span>?
+          </p>
+          {deleteTarget._count.expenses > 0 || deleteTarget._count.savingsEntries > 0 ? (
+            <p className="text-amber-400 text-xs mb-4">
+              This account has {deleteTarget._count.expenses + deleteTarget._count.savingsEntries} associated entries.
+              Remove them before deleting, or deactivate the account instead.
+            </p>
+          ) : (
+            <p className="text-gray-500 text-xs mb-4">This action cannot be undone.</p>
+          )}
+          {deleteError && (
+            <div className="bg-red-950 border border-red-800 text-red-300 px-3 py-2 rounded-lg text-xs mb-4">
+              {deleteError}
+            </div>
+          )}
+          <div className="flex gap-3">
+            <button
+              onClick={() => deleteMutation.mutate(deleteTarget.id)}
+              disabled={deleteMutation.isPending}
+              className="flex-1 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
+            </button>
+            <button
+              onClick={() => { setDeleteTarget(null); setDeleteError('') }}
+              className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
 // ── Main ProfilePage ─────────────────────────────────────────────────────────
 
-type TabKey = 'profile' | 'households'
+type TabKey = 'profile' | 'households' | 'accounts'
 
 const TABS: { key: TabKey; label: string; icon: typeof User }[] = [
   { key: 'profile', label: 'Profile', icon: User },
   { key: 'households', label: 'Households', icon: Home },
+  { key: 'accounts', label: 'Accounts', icon: CreditCard },
 ]
 
 export function ProfilePage() {
@@ -463,6 +745,7 @@ export function ProfilePage() {
         {/* Tab content */}
         {tab === 'profile' && <ProfileTab user={user} />}
         {tab === 'households' && <HouseholdsTab />}
+        {tab === 'accounts' && <AccountsTab />}
       </main>
     </div>
   )

--- a/apps/web/src/pages/SavingsPage.tsx
+++ b/apps/web/src/pages/SavingsPage.tsx
@@ -34,6 +34,25 @@ interface HouseholdMember {
   user: { id: string; name: string }
 }
 
+type AccountType = 'BANK' | 'CREDIT_CARD' | 'MOBILE_PAY'
+
+interface AccountInfo {
+  id: string
+  name: string
+  type: AccountType
+}
+
+interface AccountGroups {
+  personal: AccountInfo[]
+  household: AccountInfo[]
+}
+
+const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  BANK: 'Bank',
+  CREDIT_CARD: 'Credit card',
+  MOBILE_PAY: 'Mobile pay',
+}
+
 interface SavingsEntry {
   id: string
   label: string
@@ -50,6 +69,8 @@ interface SavingsEntry {
   categoryId: string | null
   category: SavingsCategory | null
   customSplits: { userId: string; user: { id: string; name: string }; pct: string }[]
+  accountId: string | null
+  account: AccountInfo | null
 }
 
 interface Currency {
@@ -75,13 +96,14 @@ interface EntryForm {
   ownedByUserId: string | null
   categoryId: string
   customSplits: CustomSplitInput[]
+  accountId: string | null
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const emptyForm = (baseCurrency: string): EntryForm => ({
   label: '', amount: '', frequency: 'MONTHLY', notes: '', currencyCode: baseCurrency,
-  ownership: 'SHARED', ownedByUserId: null, categoryId: '', customSplits: [],
+  ownership: 'SHARED', ownedByUserId: null, categoryId: '', customSplits: [], accountId: null,
 })
 
 function calcMonthly(amount: number, freq: Frequency): number {
@@ -115,6 +137,7 @@ export function SavingsPage() {
   const [deleteTarget, setDeleteTarget] = useState<SavingsEntry | null>(null)
   const [form, setForm] = useState<EntryForm>(emptyForm('DKK'))
   const [formError, setFormError] = useState('')
+  const [filterAccounts, setFilterAccounts] = useState<Set<string>>(new Set())
 
   // ── Queries ──────────────────────────────────────────────────────────────────
 
@@ -163,13 +186,35 @@ export function SavingsPage() {
     enabled: !!householdId,
   })
 
+  const { data: accountGroups } = useQuery<AccountGroups>({
+    queryKey: ['accounts-for-budget-year', activeBudgetYear?.id],
+    queryFn: async () => (await api.get<AccountGroups>(`/budget-years/${activeBudgetYear!.id}/accounts`)).data,
+    enabled: !!activeBudgetYear,
+  })
+  const personalAccounts = accountGroups?.personal ?? []
+  const householdAccountOptions = accountGroups?.household ?? []
+  const hasAccounts = personalAccounts.length > 0 || householdAccountOptions.length > 0
+
   const baseCurrency = config?.baseCurrency ?? 'DKK'
 
   // ── Derived ───────────────────────────────────────────────────────────────────
 
+  const accountsInEntries = useMemo(() => {
+    const map = new Map<string, AccountInfo>()
+    for (const e of entries) {
+      if (e.account) map.set(e.account.id, e.account)
+    }
+    return [...map.values()].sort((a, b) => a.name.localeCompare(b.name))
+  }, [entries])
+
+  const filteredEntries = useMemo(() => {
+    if (filterAccounts.size === 0) return entries
+    return entries.filter((e) => e.accountId != null && filterAccounts.has(e.accountId))
+  }, [entries, filterAccounts])
+
   const totalMonthly = useMemo(
-    () => entries.reduce((s, e) => s + parseFloat(e.monthlyEquivalent), 0),
-    [entries]
+    () => filteredEntries.reduce((s, e) => s + parseFloat(e.monthlyEquivalent), 0),
+    [filteredEntries]
   )
 
   const selectedCurrencyRate = currencies.find((c) => c.code === form.currencyCode)?.rate ?? 1
@@ -199,6 +244,7 @@ export function SavingsPage() {
         customSplits: data.ownership === 'CUSTOM'
           ? data.customSplits.map((s) => ({ userId: s.userId, pct: parseFloat(s.pct) }))
           : undefined,
+        accountId: data.accountId || null,
       }),
     onSuccess: () => {
       invalidate()
@@ -227,6 +273,7 @@ export function SavingsPage() {
         customSplits: data.ownership === 'CUSTOM'
           ? data.customSplits.map((s) => ({ userId: s.userId, pct: parseFloat(s.pct) }))
           : undefined,
+        accountId: data.accountId || null,
       }),
     onSuccess: () => {
       invalidate()
@@ -266,6 +313,7 @@ export function SavingsPage() {
       ownedByUserId: e.ownedByUserId ?? null,
       categoryId: e.categoryId ?? '',
       customSplits: e.customSplits?.map((s) => ({ userId: s.userId, pct: s.pct })) ?? [],
+      accountId: e.account?.id ?? null,
     })
     setFormError('')
     setEditingEntry(e)
@@ -336,6 +384,35 @@ export function SavingsPage() {
           ) : undefined}
         />
 
+        {accountsInEntries.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap mb-4">
+            <span className="text-xs text-gray-500 mr-1">Account:</span>
+            {accountsInEntries.map((a) => (
+              <button
+                key={a.id}
+                onClick={() => setFilterAccounts((prev) => {
+                  const next = new Set(prev)
+                  if (next.has(a.id)) next.delete(a.id); else next.add(a.id)
+                  return next
+                })}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  filterAccounts.has(a.id)
+                    ? 'bg-amber-400 border-amber-400 text-gray-950 font-medium'
+                    : 'bg-gray-800 border-gray-700 text-gray-400 hover:text-white'
+                }`}
+              >
+                {a.name}
+                <span className="ml-1 opacity-60">{ACCOUNT_TYPE_LABELS[a.type]}</span>
+              </button>
+            ))}
+            {filterAccounts.size > 0 && (
+              <button onClick={() => setFilterAccounts(new Set())} className="text-xs text-gray-600 hover:text-gray-400 transition-colors ml-1">
+                Clear
+              </button>
+            )}
+          </div>
+        )}
+
         {yearsLoading ? (
           <PageLoader />
         ) : !activeBudgetYear ? (
@@ -370,7 +447,7 @@ export function SavingsPage() {
                 </tr>
               </thead>
               <tbody>
-                {entries.map((e) => (
+                {filteredEntries.map((e) => (
                   <tr key={e.id} className="border-b border-gray-800 last:border-0 hover:bg-gray-800/40 group">
                     <td className="px-4 py-3 text-white">
                       <div className="flex items-center gap-2 flex-wrap">
@@ -386,6 +463,11 @@ export function SavingsPage() {
                           </span>
                         )}
                         {e.notes && <span className="ml-1 text-gray-600 text-xs" title={e.notes}>📝</span>}
+                        {e.account && (
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-gray-800 text-gray-400 border border-gray-700">
+                            {e.account.name}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="px-4 py-3 text-gray-300">
@@ -425,7 +507,7 @@ export function SavingsPage() {
               <tfoot>
                 <tr className="border-t border-gray-700 bg-gray-800/50">
                   <td colSpan={colSpan - 1} className="px-4 py-3 text-sm text-gray-400 font-medium">
-                    Total — {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+                    Total{filterAccounts.size > 0 ? ' (filtered)' : ''} — {filteredEntries.length} {filteredEntries.length === 1 ? 'entry' : 'entries'}
                   </td>
                   <td className="px-4 py-3 text-right text-amber-400 font-bold tabular-nums">{fmt(totalMonthly)}</td>
                   {!isReadOnly && <td />}
@@ -527,6 +609,35 @@ export function SavingsPage() {
                     {savingsCategories.map((c) => (
                       <option key={c.id} value={c.id}>{c.name}{c.isSystemWide ? '' : ' (custom)'}</option>
                     ))}
+                  </select>
+                </div>
+              )}
+
+              {hasAccounts && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-400 mb-1">
+                    Account <span className="text-gray-600">(optional)</span>
+                  </label>
+                  <select
+                    value={form.accountId ?? ''}
+                    onChange={(e) => setForm({ ...form, accountId: e.target.value || null })}
+                    className={inputClass}
+                  >
+                    <option value="">— None —</option>
+                    {personalAccounts.length > 0 && (
+                      <optgroup label="My accounts">
+                        {personalAccounts.map((a) => (
+                          <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                        ))}
+                      </optgroup>
+                    )}
+                    {householdAccountOptions.length > 0 && (
+                      <optgroup label="Household accounts">
+                        {householdAccountOptions.map((a) => (
+                          <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                        ))}
+                      </optgroup>
+                    )}
                   </select>
                 </div>
               )}

--- a/prisma/migrations/20260402000000_add_accounts/migration.sql
+++ b/prisma/migrations/20260402000000_add_accounts/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "AccountType" AS ENUM ('BANK', 'CREDIT_CARD', 'MOBILE_PAY');
+
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "AccountType" NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "ownedByUserId" TEXT,
+    "householdId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Account_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN "accountId" TEXT;
+
+-- AlterTable
+ALTER TABLE "SavingsEntry" ADD COLUMN "accountId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_ownedByUserId_fkey" FOREIGN KEY ("ownedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SavingsEntry" ADD CONSTRAINT "SavingsEntry_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,12 @@ enum SavingsOwnership {
   CUSTOM
 }
 
+enum AccountType {
+  BANK
+  CREDIT_CARD
+  MOBILE_PAY
+}
+
 model User {
   id                        String                     @id @default(cuid())
   email                     String                     @unique
@@ -79,6 +85,7 @@ model User {
   expenseCustomSplits       ExpenseCustomSplit[]   @relation("ExpenseCustomSplits")
   ownedSavings              SavingsEntry[]         @relation("OwnedSavings")
   savingsCustomSplits       SavingsCustomSplit[]   @relation("SavingsCustomSplits")
+  ownedAccounts             Account[]              @relation("OwnedAccounts")
 }
 
 model UserPreferences {
@@ -105,6 +112,7 @@ model Household {
 
   members     HouseholdMember[]
   budgetYears BudgetYear[]
+  accounts    Account[]
 }
 
 model HouseholdMember {
@@ -228,6 +236,21 @@ model Category {
   @@map("ExpenseCategory")
 }
 
+model Account {
+  id             String        @id @default(cuid())
+  name           String
+  type           AccountType
+  isActive       Boolean       @default(true)
+  ownedByUserId  String?
+  ownedBy        User?         @relation("OwnedAccounts", fields: [ownedByUserId], references: [id], onDelete: SetNull)
+  householdId    String?
+  household      Household?    @relation(fields: [householdId], references: [id], onDelete: Cascade)
+  expenses       Expense[]
+  savingsEntries SavingsEntry[]
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+}
+
 model Expense {
   id                String           @id @default(cuid())
   budgetYear        BudgetYear       @relation(fields: [budgetYearId], references: [id])
@@ -249,6 +272,8 @@ model Expense {
   ownership         ExpenseOwnership @default(SHARED)
   ownedByUserId     String?
   ownedBy           User?            @relation("OwnedExpenses", fields: [ownedByUserId], references: [id], onDelete: SetNull)
+  accountId         String?
+  account           Account?         @relation(fields: [accountId], references: [id], onDelete: SetNull)
   customSplits      ExpenseCustomSplit[]
   createdAt         DateTime         @default(now())
   updatedAt         DateTime         @updatedAt
@@ -282,6 +307,8 @@ model SavingsEntry {
   ownership         SavingsOwnership @default(SHARED)
   ownedByUserId     String?
   ownedBy           User?            @relation("OwnedSavings", fields: [ownedByUserId], references: [id], onDelete: SetNull)
+  accountId         String?
+  account           Account?         @relation(fields: [accountId], references: [id], onDelete: SetNull)
   categoryId        String?
   category          Category?        @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   customSplits      SavingsCustomSplit[]


### PR DESCRIPTION
Adds full Account management (BANK, CREDIT_CARD, MOBILE_PAY) with personal
accounts per user and household-level accounts. Expenses and savings entries
gain an optional account tag, with filtering, badges, and a dashboard
breakdown by account.

- Prisma: Account model + AccountType enum; optional accountId FK on
  Expense and SavingsEntry; migration SQL in prisma/migrations/
- API: new accountRoutes with personal (/users/me/accounts) and household
  (/households/:id/accounts) CRUD, combined endpoint for form dropdowns
  (/budget-years/:id/accounts), and 409 deletion safeguard; accountId
  support added to expenses and savings routes; byAccount aggregation
  added to dashboard summary response
- UI: Accounts tab in ProfilePage for personal accounts; Accounts section
  in HouseholdPage (admin write, member read); account dropdown in
  expense and savings forms (grouped by personal/household); account
  badge on list items; account filter pills; by-account breakdown on
  dashboard

https://claude.ai/code/session_01SgxRPC3oeGXzLf4yKQWPUa