### PR TITLE
feat: forward-looking monthly budget calculation — Sprint 23 (#133–140)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,7 +19,10 @@ import { savingsRoutes } from './routes/savings'
 import { currencyRoutes } from './routes/currencies'
 import { profileRoutes } from './routes/profile'
 import { accountRoutes } from './routes/accounts'
+import { budgetTransferRoutes } from './routes/budgetTransfers'
+import { automationRoutes } from './routes/automations'
 import { syncRates, BASE_CURRENCY } from './lib/currency'
+import { runAllEnabledAutomations } from './lib/automations'
 import { prisma } from './lib/prisma'
 
 const VERSION = process.env.npm_package_version ?? '0.14.0'
@@ -60,6 +63,8 @@ app.register(compareRoutes)
 app.register(savingsRoutes)
 app.register(currencyRoutes)
 app.register(profileRoutes)
+app.register(budgetTransferRoutes)
+app.register(automationRoutes)
 
 // Health check
 app.get('/health', async () => {
@@ -88,6 +93,13 @@ const start = async () => {
         app.log.warn({ err }, 'Initial currency sync failed — rates will load on next daily sync')
       }
     }
+
+    // Monthly budget transfer snapshot on the 1st of each month at 00:00
+    cron.schedule('0 0 1 * *', () => {
+      runAllEnabledAutomations('SCHEDULE').catch((err) =>
+        app.log.error({ err }, 'monthly_transfer_snapshot automation failed'),
+      )
+    })
 
     // Daily currency rate sync at 06:00
     cron.schedule('0 6 * * *', async () => {

--- a/apps/api/src/lib/automations.ts
+++ b/apps/api/src/lib/automations.ts
@@ -1,0 +1,74 @@
+import { AutomationTrigger } from '@prisma/client'
+import { prisma } from './prisma'
+import { recalculateTransfer } from './budgetTransfer'
+
+export async function runAutomation(
+  automationId: string,
+  triggeredBy: AutomationTrigger,
+  userId?: string,
+): Promise<void> {
+  const startedAt = new Date()
+
+  const automation = await prisma.automation.findUnique({ where: { id: automationId } })
+  if (!automation) return
+
+  if (!automation.isEnabled) {
+    const finishedAt = new Date()
+    await prisma.automationRun.create({
+      data: { automationId, triggeredBy, triggeredByUserId: userId ?? null, startedAt, finishedAt, status: 'SKIPPED', message: 'Automation is disabled' },
+    })
+    await prisma.automation.update({
+      where: { id: automationId },
+      data: { lastRunAt: finishedAt, lastRunStatus: 'SKIPPED' },
+    })
+    return
+  }
+
+  try {
+    const activeBudgetYear = await prisma.budgetYear.findFirst({
+      where: { householdId: automation.householdId, status: 'ACTIVE' },
+    })
+
+    if (!activeBudgetYear) {
+      const finishedAt = new Date()
+      await prisma.automationRun.create({
+        data: { automationId, triggeredBy, triggeredByUserId: userId ?? null, startedAt, finishedAt, status: 'SKIPPED', message: 'No active budget year found' },
+      })
+      await prisma.automation.update({
+        where: { id: automationId },
+        data: { lastRunAt: finishedAt, lastRunStatus: 'SKIPPED' },
+      })
+      return
+    }
+
+    await recalculateTransfer(activeBudgetYear.id)
+
+    const finishedAt = new Date()
+    await prisma.automationRun.create({
+      data: { automationId, triggeredBy, triggeredByUserId: userId ?? null, startedAt, finishedAt, status: 'SUCCESS' },
+    })
+    await prisma.automation.update({
+      where: { id: automationId },
+      data: { lastRunAt: finishedAt, lastRunStatus: 'SUCCESS' },
+    })
+  } catch (err) {
+    const finishedAt = new Date()
+    const message = err instanceof Error ? err.message : String(err)
+    await prisma.automationRun.create({
+      data: { automationId, triggeredBy, triggeredByUserId: userId ?? null, startedAt, finishedAt, status: 'ERROR', message },
+    })
+    await prisma.automation.update({
+      where: { id: automationId },
+      data: { lastRunAt: finishedAt, lastRunStatus: 'ERROR' },
+    })
+  }
+}
+
+export async function runAllEnabledAutomations(
+  triggeredBy: AutomationTrigger,
+  userId?: string,
+): Promise<number> {
+  const automations = await prisma.automation.findMany({ where: { isEnabled: true } })
+  await Promise.all(automations.map((a) => runAutomation(a.id, triggeredBy, userId)))
+  return automations.length
+}

--- a/apps/api/src/lib/budgetTransfer.ts
+++ b/apps/api/src/lib/budgetTransfer.ts
@@ -1,0 +1,43 @@
+import { prisma } from './prisma'
+import { calcForwardMonthlyNeed } from './calculations'
+
+export async function recalculateTransfer(budgetYearId: string): Promise<void> {
+  const budgetYear = await prisma.budgetYear.findUnique({ where: { id: budgetYearId } })
+  if (!budgetYear || budgetYear.status !== 'ACTIVE') return
+
+  const targetMonth = new Date().getMonth() + 1 // 1-12
+  const year = budgetYear.year
+
+  const expenses = await prisma.expense.findMany({
+    where: { budgetYearId },
+    select: { monthlyEquivalent: true },
+  })
+
+  const paidTransfers = await prisma.budgetTransfer.findMany({
+    where: { budgetYearId, status: { in: ['PAID', 'ADJUSTED'] } },
+    select: { actualAmount: true },
+  })
+
+  const calculatedAmount = calcForwardMonthlyNeed(expenses, paidTransfers, targetMonth)
+
+  const existing = await prisma.budgetTransfer.findUnique({
+    where: { budgetYearId_month_year: { budgetYearId, month: targetMonth, year } },
+  })
+
+  if (!existing || existing.status === 'PENDING') {
+    await prisma.budgetTransfer.upsert({
+      where: { budgetYearId_month_year: { budgetYearId, month: targetMonth, year } },
+      create: { budgetYearId, year, month: targetMonth, calculatedAmount, calculatedAt: new Date() },
+      update: { calculatedAmount, calculatedAt: new Date() },
+    })
+  } else {
+    // Current month is PAID/ADJUSTED — write to next month's row instead
+    const nextMonth = targetMonth === 12 ? 1 : targetMonth + 1
+    const nextYear = targetMonth === 12 ? year + 1 : year
+    await prisma.budgetTransfer.upsert({
+      where: { budgetYearId_month_year: { budgetYearId, month: nextMonth, year: nextYear } },
+      create: { budgetYearId, year: nextYear, month: nextMonth, calculatedAmount, calculatedAt: new Date() },
+      update: { calculatedAmount, calculatedAt: new Date() },
+    })
+  }
+}

--- a/apps/api/src/lib/calculations.test.ts
+++ b/apps/api/src/lib/calculations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Decimal } from '@prisma/client/runtime/client'
-import { calcMonthlyEquivalent, deriveBudgetStatus } from './calculations'
+import { calcMonthlyEquivalent, calcForwardMonthlyNeed, deriveBudgetStatus } from './calculations'
 
 // ── calcMonthlyEquivalent ─────────────────────────────────────────────────────
 
@@ -43,6 +43,57 @@ describe('calcMonthlyEquivalent', () => {
 
   it('handles zero amount', () => {
     expect(calcMonthlyEquivalent(d('0'), 'MONTHLY').toNumber()).toBe(0)
+  })
+})
+
+// ── calcForwardMonthlyNeed ────────────────────────────────────────────────────
+
+describe('calcForwardMonthlyNeed', () => {
+  const d = (v: string) => new Decimal(v)
+
+  // expenses with monthlyEquivalent of 100 → annualNeed = 100 * 12 = 1200
+  const expenses100 = [{ monthlyEquivalent: d('100') }]
+  const noPaid: { actualAmount: Decimal | null }[] = []
+
+  it('January (month 1), no paid → annualNeed / 12', () => {
+    // remainingMonths = 13 - 1 = 12; result = 1200 / 12 = 100
+    expect(calcForwardMonthlyNeed(expenses100, noPaid, 1).toNumber()).toBeCloseTo(100, 2)
+  })
+
+  it('July (month 7), no paid → annualNeed / 6', () => {
+    // remainingMonths = 13 - 7 = 6; result = 1200 / 6 = 200
+    expect(calcForwardMonthlyNeed(expenses100, noPaid, 7).toNumber()).toBeCloseTo(200, 2)
+  })
+
+  it('month 12, no paid → full annualNeed (remainingMonths = 1)', () => {
+    // remainingMonths = 13 - 12 = 1; result = 1200 / 1 = 1200
+    expect(calcForwardMonthlyNeed(expenses100, noPaid, 12).toNumber()).toBeCloseTo(1200, 2)
+  })
+
+  it('all transfers already paid (total = annualNeed) → 0', () => {
+    const paid = [{ actualAmount: d('1200') }]
+    expect(calcForwardMonthlyNeed(expenses100, paid, 1).toNumber()).toBe(0)
+  })
+
+  it('multiple paid transfers are correctly subtracted', () => {
+    // annualNeed = 1200, paid = 300 + 200 = 500, remaining = 700, remainingMonths = 6
+    const paid = [{ actualAmount: d('300') }, { actualAmount: d('200') }]
+    expect(calcForwardMonthlyNeed(expenses100, paid, 7).toNumber()).toBeCloseTo(700 / 6, 2)
+  })
+
+  it('result never goes negative when paid exceeds annualNeed', () => {
+    const paid = [{ actualAmount: d('2000') }]
+    expect(calcForwardMonthlyNeed(expenses100, paid, 6).toNumber()).toBe(0)
+  })
+
+  it('null actualAmount in paid transfers is treated as 0', () => {
+    const paid = [{ actualAmount: null }, { actualAmount: d('600') }]
+    // alreadyPaid = 600, remaining = 600, remainingMonths = 12
+    expect(calcForwardMonthlyNeed(expenses100, paid, 1).toNumber()).toBeCloseTo(50, 2)
+  })
+
+  it('no expenses → 0 regardless of month', () => {
+    expect(calcForwardMonthlyNeed([], noPaid, 6).toNumber()).toBe(0)
   })
 })
 

--- a/apps/api/src/lib/calculations.ts
+++ b/apps/api/src/lib/calculations.ts
@@ -34,6 +34,30 @@ export function calcAnnualAverage(monthlyEquivalent: Decimal, startMonth: number
   return new Decimal(monthlyEquivalent.toString()).mul(months).div(12)
 }
 
+/**
+ * Calculates the recommended transfer amount for a given target month.
+ * Formula: max(0, (annualNeed - alreadyPaid) / remainingMonths)
+ * where remainingMonths = 13 - targetMonth
+ */
+export function calcForwardMonthlyNeed(
+  expenses: { monthlyEquivalent: Decimal }[],
+  paidTransfers: { actualAmount: Decimal | null }[],
+  targetMonth: number, // 1-12
+): Decimal {
+  const annualNeed = expenses.reduce(
+    (sum, e) => sum.add(new Decimal(e.monthlyEquivalent.toString()).mul(12)),
+    new Decimal(0),
+  )
+  const alreadyPaid = paidTransfers.reduce(
+    (sum, t) => sum.add(t.actualAmount ? new Decimal(t.actualAmount.toString()) : new Decimal(0)),
+    new Decimal(0),
+  )
+  const remaining = annualNeed.sub(alreadyPaid)
+  if (remaining.lte(0)) return new Decimal(0)
+  const remainingMonths = new Decimal(13 - targetMonth)
+  return remaining.div(remainingMonths)
+}
+
 export function deriveBudgetStatus(year: number): 'ACTIVE' | 'FUTURE' | 'RETIRED' {
   const current = new Date().getFullYear()
   if (year < current) return 'RETIRED'

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -1,0 +1,66 @@
+import { FastifyInstance } from 'fastify'
+import { prisma } from '../lib/prisma'
+import { authenticate, requireAdmin } from '../plugins/authenticate'
+import { runAutomation, runAllEnabledAutomations } from '../lib/automations'
+
+export async function automationRoutes(fastify: FastifyInstance) {
+  // GET /admin/automations
+  fastify.get('/admin/automations', { preHandler: [authenticate, requireAdmin] }, async (_request, reply) => {
+    const automations = await prisma.automation.findMany({
+      include: {
+        household: { select: { id: true, name: true } },
+        _count: { select: { runs: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+    return reply.send(automations)
+  })
+
+  // PATCH /admin/automations/:id/toggle
+  fastify.patch('/admin/automations/:id/toggle', { preHandler: [authenticate, requireAdmin] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+
+    const automation = await prisma.automation.findUnique({ where: { id } })
+    if (!automation) return reply.status(404).send({ error: 'Automation not found' })
+
+    const updated = await prisma.automation.update({
+      where: { id },
+      data: { isEnabled: !automation.isEnabled },
+    })
+    return reply.send(updated)
+  })
+
+  // GET /admin/automations/:id/runs
+  fastify.get('/admin/automations/:id/runs', { preHandler: [authenticate, requireAdmin] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+
+    const automation = await prisma.automation.findUnique({ where: { id } })
+    if (!automation) return reply.status(404).send({ error: 'Automation not found' })
+
+    const runs = await prisma.automationRun.findMany({
+      where: { automationId: id },
+      orderBy: { startedAt: 'desc' },
+      take: 50,
+    })
+    return reply.send(runs)
+  })
+
+  // POST /admin/automations/:id/trigger
+  fastify.post('/admin/automations/:id/trigger', { preHandler: [authenticate, requireAdmin] }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId } = request.user
+
+    const automation = await prisma.automation.findUnique({ where: { id } })
+    if (!automation) return reply.status(404).send({ error: 'Automation not found' })
+
+    await runAutomation(id, 'MANUAL', userId)
+    return reply.send({ success: true })
+  })
+
+  // POST /admin/automations/trigger-all
+  fastify.post('/admin/automations/trigger-all', { preHandler: [authenticate, requireAdmin] }, async (request, reply) => {
+    const { sub: userId } = request.user
+    const triggered = await runAllEnabledAutomations('MANUAL', userId)
+    return reply.send({ triggered })
+  })
+}

--- a/apps/api/src/routes/budgetTransfers.ts
+++ b/apps/api/src/routes/budgetTransfers.ts
@@ -1,0 +1,87 @@
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { Decimal } from '@prisma/client/runtime/client'
+import { prisma } from '../lib/prisma'
+import { authenticate } from '../plugins/authenticate'
+import { assertBudgetYearAccess } from '../lib/ownership'
+
+const MarkPaidSchema = z.object({
+  actualAmount: z.number().positive(),
+})
+
+export async function budgetTransferRoutes(fastify: FastifyInstance) {
+  // GET /budget-years/:id/transfers
+  fastify.get('/budget-years/:id/transfers', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+
+    const transfers = await prisma.budgetTransfer.findMany({
+      where: { budgetYearId: id },
+      orderBy: [{ year: 'desc' }, { month: 'desc' }],
+    })
+
+    return reply.send(transfers)
+  })
+
+  // PATCH /budget-years/:id/transfers/:transferId/mark-paid
+  fastify.patch('/budget-years/:id/transfers/:transferId/mark-paid', { preHandler: authenticate }, async (request, reply) => {
+    const { id, transferId } = request.params as { id: string; transferId: string }
+    const { sub: userId, role } = request.user
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+
+    const result = MarkPaidSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const transfer = await prisma.budgetTransfer.findUnique({ where: { id: transferId } })
+    if (!transfer || transfer.budgetYearId !== id) {
+      return reply.status(404).send({ error: 'Transfer not found' })
+    }
+
+    const { actualAmount } = result.data
+    const calculatedAmount = parseFloat(transfer.calculatedAmount.toString())
+    const status = actualAmount === calculatedAmount ? 'PAID' : 'ADJUSTED'
+
+    const updated = await prisma.budgetTransfer.update({
+      where: { id: transferId },
+      data: {
+        actualAmount: new Decimal(actualAmount),
+        status,
+        paidAt: new Date(),
+      },
+    })
+
+    return reply.send(updated)
+  })
+
+  // PATCH /budget-years/:id/transfers/:transferId/mark-pending
+  fastify.patch('/budget-years/:id/transfers/:transferId/mark-pending', { preHandler: authenticate }, async (request, reply) => {
+    const { id, transferId } = request.params as { id: string; transferId: string }
+    const { sub: userId, role } = request.user
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+
+    const transfer = await prisma.budgetTransfer.findUnique({ where: { id: transferId } })
+    if (!transfer || transfer.budgetYearId !== id) {
+      return reply.status(404).send({ error: 'Transfer not found' })
+    }
+
+    const updated = await prisma.budgetTransfer.update({
+      where: { id: transferId },
+      data: {
+        status: 'PENDING',
+        actualAmount: null,
+        paidAt: null,
+      },
+    })
+
+    return reply.send(updated)
+  })
+}

--- a/apps/api/src/routes/expenses.ts
+++ b/apps/api/src/routes/expenses.ts
@@ -7,6 +7,7 @@ import { calcMonthlyEquivalent, calcAnnualAverage } from '../lib/calculations'
 import { getLatestRate, BASE_CURRENCY } from '../lib/currency'
 import { assertBudgetYearAccess, validateOwnership } from '../lib/ownership'
 import { toNum } from '../lib/decimal'
+import { recalculateTransfer } from '../lib/budgetTransfer'
 
 const FrequencyEnum = z.enum(['WEEKLY', 'FORTNIGHTLY', 'MONTHLY', 'QUARTERLY', 'BIANNUAL', 'ANNUAL'])
 
@@ -146,6 +147,7 @@ export async function expenseRoutes(fastify: FastifyInstance) {
       return created
     })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.status(201).send(expense)
   })
 
@@ -255,6 +257,7 @@ export async function expenseRoutes(fastify: FastifyInstance) {
       return updated
     })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.send(expense)
   })
 
@@ -273,6 +276,7 @@ export async function expenseRoutes(fastify: FastifyInstance) {
 
     await prisma.expense.delete({ where: { id: expenseId } })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.status(204).send()
   })
 }

--- a/apps/api/src/routes/households.ts
+++ b/apps/api/src/routes/households.ts
@@ -80,6 +80,16 @@ export async function householdRoutes(fastify: FastifyInstance) {
       },
     })
 
+    await prisma.automation.create({
+      data: {
+        key: 'monthly_transfer_snapshot',
+        label: 'Monthly budget transfer calculation',
+        description: 'Calculates and records the recommended monthly transfer on the 1st of each month',
+        schedule: '0 0 1 * *',
+        householdId: household.id,
+      },
+    })
+
     return reply.status(201).send({ ...household, myRole: 'ADMIN' })
   })
 

--- a/apps/api/src/routes/savings.ts
+++ b/apps/api/src/routes/savings.ts
@@ -8,6 +8,7 @@ import { getLatestRate, BASE_CURRENCY } from '../lib/currency'
 import { calcIncomeForYear, getIncomeReferenceDate } from '../lib/incomeCalc'
 import { assertBudgetYearAccess, assertHouseholdAccess, validateOwnership } from '../lib/ownership'
 import { toNum } from '../lib/decimal'
+import { recalculateTransfer } from '../lib/budgetTransfer'
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 
@@ -130,6 +131,7 @@ export async function savingsRoutes(fastify: FastifyInstance) {
       return created
     })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.status(201).send(entry)
   })
 
@@ -225,6 +227,7 @@ export async function savingsRoutes(fastify: FastifyInstance) {
       return savedEntry
     })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.send(updated)
   })
 
@@ -242,6 +245,7 @@ export async function savingsRoutes(fastify: FastifyInstance) {
 
     await prisma.savingsEntry.delete({ where: { id: entryId } })
 
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.status(204).send()
   })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import { HouseholdsAdminPage } from './pages/admin/HouseholdsAdminPage'
 import { CategoriesPage } from './pages/CategoriesPage'
 import { CategoriesAdminPage } from './pages/admin/CategoriesAdminPage'
 import { CurrenciesAdminPage } from './pages/admin/CurrenciesAdminPage'
+import { AutomationsAdminPage } from './pages/admin/AutomationsAdminPage'
 import { ForbiddenPage } from './pages/ForbiddenPage'
 import { ExpensesPage } from './pages/ExpensesPage'
 import { IncomePage } from './pages/IncomePage'
@@ -70,6 +71,7 @@ function App() {
               <Route path="households" element={<HouseholdsAdminPage />} />
               <Route path="currencies" element={<CurrenciesAdminPage />} />
               <Route path="categories" element={<CategoriesAdminPage />} />
+              <Route path="automations" element={<AutomationsAdminPage />} />
             </Route>
 
             {/* Standalone personal routes — shared GlobalLayout */}

--- a/apps/web/src/hooks/useTransfers.ts
+++ b/apps/web/src/hooks/useTransfers.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../api/client'
+
+export interface BudgetTransfer {
+  id: string
+  budgetYearId: string
+  year: number
+  month: number
+  calculatedAmount: string
+  actualAmount: string | null
+  status: 'PENDING' | 'PAID' | 'ADJUSTED'
+  calculatedAt: string
+  paidAt: string | null
+  automationRunId: string | null
+}
+
+export function useTransfers(budgetYearId: string | undefined) {
+  return useQuery<BudgetTransfer[]>({
+    queryKey: ['transfers', budgetYearId],
+    queryFn: async () => (await api.get<BudgetTransfer[]>(`/budget-years/${budgetYearId}/transfers`)).data,
+    enabled: !!budgetYearId,
+  })
+}

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -3,10 +3,11 @@ import { AppFooter } from '../components/AppFooter'
 import HeaderUserMenu from '../components/HeaderUserMenu'
 
 const ADMIN_NAV = [
-  { label: 'Users',       path: '/admin/users' },
-  { label: 'Households',  path: '/admin/households' },
-  { label: 'Currencies',  path: '/admin/currencies' },
-  { label: 'Categories',  path: '/admin/categories' },
+  { label: 'Users',        path: '/admin/users' },
+  { label: 'Households',   path: '/admin/households' },
+  { label: 'Currencies',   path: '/admin/currencies' },
+  { label: 'Categories',   path: '/admin/categories' },
+  { label: 'Automations',  path: '/admin/automations' },
 ]
 
 export function AdminLayout() {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ArrowRightLeft } from 'lucide-react'
 import { api } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { CategoryIcon } from '../components/CategoryIcon'
@@ -8,6 +9,7 @@ import { PageLoader } from '../components/LoadingSpinner'
 import { SankeyChart, type SankeyNodeDef, type SankeyLinkDef } from '../components/SankeyChart'
 import { FREQ_LABELS } from '../lib/constants'
 import { useFmt, useBaseCurrency } from '../hooks/useFmt'
+import { useTransfers, type BudgetTransfer } from '../hooks/useTransfers'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -122,6 +124,12 @@ export function DashboardPage() {
   // SAV-003: affordability slider (extra monthly savings)
   const [extraSavings, setExtraSavings] = useState(0)
 
+  // Budget transfer state
+  const [markPaidTransfer, setMarkPaidTransfer] = useState<BudgetTransfer | null>(null)
+  const [markPaidAmount, setMarkPaidAmount] = useState('')
+  const [markPaidLoading, setMarkPaidLoading] = useState(false)
+  const [historyCollapsed, setHistoryCollapsed] = useState(false)
+
   const { data: household } = useQuery<Household>({
     queryKey: ['household', householdId],
     queryFn: async () => (await api.get<Household>(`/households/${householdId}`)).data,
@@ -139,6 +147,41 @@ export function DashboardPage() {
     queryFn: async () => (await api.get<DashboardSummary>(`/households/${householdId}/summary`)).data,
     enabled: !!householdId,
   })
+
+  const queryClient = useQueryClient()
+  const { data: transfers = [] } = useTransfers(summary?.budgetYear?.id)
+
+  const now = new Date()
+  const currentMonth = now.getMonth() + 1
+  const currentYear = now.getFullYear()
+  const pendingThisMonth = transfers.find(
+    (t) => t.status === 'PENDING' && t.month === currentMonth && t.year === currentYear,
+  )
+
+  const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+  async function handleMarkPaid() {
+    if (!markPaidTransfer || !summary?.budgetYear) return
+    setMarkPaidLoading(true)
+    try {
+      await api.patch(
+        `/budget-years/${summary.budgetYear.id}/transfers/${markPaidTransfer.id}/mark-paid`,
+        { actualAmount: parseFloat(markPaidAmount) },
+      )
+      queryClient.invalidateQueries({ queryKey: ['transfers', summary.budgetYear.id] })
+      setMarkPaidTransfer(null)
+    } finally {
+      setMarkPaidLoading(false)
+    }
+  }
+
+  async function handleRevert(transfer: BudgetTransfer) {
+    if (!summary?.budgetYear) return
+    await api.patch(
+      `/budget-years/${summary.budgetYear.id}/transfers/${transfer.id}/mark-pending`,
+    )
+    queryClient.invalidateQueries({ queryKey: ['transfers', summary.budgetYear.id] })
+  }
 
   function dismiss(key: string) {
     setDismissed((prev) => new Set([...prev, key]))
@@ -516,6 +559,147 @@ export function DashboardPage() {
                     </div>
                   )
                 })}
+              </div>
+            </div>
+          )}
+
+          {/* Budget transfer tile */}
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-8">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <ArrowRightLeft size={16} className="text-amber-400" />
+                <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wide">Transfer due this month</h2>
+              </div>
+            </div>
+            {pendingThisMonth ? (
+              <div className="flex items-center justify-between">
+                <span className="text-2xl font-bold text-amber-400">{fmt(pendingThisMonth.calculatedAmount)}</span>
+                <button
+                  onClick={() => {
+                    setMarkPaidTransfer(pendingThisMonth)
+                    setMarkPaidAmount(pendingThisMonth.calculatedAmount)
+                  }}
+                  className="bg-amber-500 hover:bg-amber-400 text-gray-950 font-medium text-sm px-4 py-2 rounded-lg transition-colors"
+                >
+                  Mark as Paid
+                </button>
+              </div>
+            ) : (
+              <p className="text-gray-500 text-sm">No transfer pending this month</p>
+            )}
+          </div>
+
+          {/* Transfer history */}
+          <div className="mb-8">
+            <button
+              onClick={() => setHistoryCollapsed((c) => !c)}
+              className="flex items-center gap-2 text-sm font-medium text-gray-400 uppercase tracking-wide mb-3 hover:text-gray-300 transition-colors"
+            >
+              <span>Transfer History</span>
+              <span className="text-gray-600">{historyCollapsed ? '▸' : '▾'}</span>
+            </button>
+            {!historyCollapsed && (
+              transfers.length === 0 ? (
+                <p className="text-gray-600 text-sm py-4 text-center bg-gray-900 border border-gray-800 rounded-xl">
+                  No transfers recorded yet
+                </p>
+              ) : (
+                <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-gray-800 text-gray-400 text-left">
+                        <th className="px-4 py-3 font-medium">Month</th>
+                        <th className="px-4 py-3 font-medium text-right">Calculated</th>
+                        <th className="px-4 py-3 font-medium text-right">Actual</th>
+                        <th className="px-4 py-3 font-medium">Status</th>
+                        <th className="px-4 py-3 font-medium"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {transfers.map((t) => (
+                        <tr key={t.id} className="border-b border-gray-800 last:border-0 hover:bg-gray-800/40">
+                          <td className="px-4 py-3 text-white tabular-nums">
+                            {MONTH_NAMES[(t.month - 1) % 12]} {t.year}
+                          </td>
+                          <td className="px-4 py-3 text-right tabular-nums text-gray-300">{fmt(t.calculatedAmount)}</td>
+                          <td className="px-4 py-3 text-right tabular-nums text-gray-300">
+                            {t.actualAmount ? fmt(t.actualAmount) : '—'}
+                          </td>
+                          <td className="px-4 py-3">
+                            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                              t.status === 'PAID' ? 'bg-green-900/50 text-green-300' :
+                              t.status === 'ADJUSTED' ? 'bg-amber-900/50 text-amber-300' :
+                              'bg-gray-800 text-gray-400'
+                            }`}>
+                              {t.status}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            {t.status === 'PENDING' ? (
+                              <button
+                                onClick={() => {
+                                  setMarkPaidTransfer(t)
+                                  setMarkPaidAmount(t.calculatedAmount)
+                                }}
+                                className="text-amber-400 hover:text-amber-300 text-xs font-medium transition-colors"
+                              >
+                                Mark as Paid
+                              </button>
+                            ) : (
+                              <div className="flex items-center justify-end gap-2 text-xs text-gray-500">
+                                {t.paidAt && <span>{new Date(t.paidAt).toLocaleDateString()}</span>}
+                                <button
+                                  onClick={() => handleRevert(t)}
+                                  className="text-gray-500 hover:text-gray-300 transition-colors"
+                                >
+                                  Revert
+                                </button>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )
+            )}
+          </div>
+
+          {/* Mark as Paid modal */}
+          {markPaidTransfer && (
+            <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 px-4">
+              <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 w-full max-w-sm">
+                <h3 className="text-lg font-semibold text-white mb-1">Mark Transfer as Paid</h3>
+                <p className="text-gray-400 text-sm mb-4">
+                  {MONTH_NAMES[(markPaidTransfer.month - 1) % 12]} {markPaidTransfer.year}
+                </p>
+                <label className="block text-xs text-gray-400 uppercase tracking-wide mb-1">
+                  Actual amount transferred
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={markPaidAmount}
+                  onChange={(e) => setMarkPaidAmount(e.target.value)}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm mb-4 focus:outline-none focus:border-amber-500"
+                />
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleMarkPaid}
+                    disabled={markPaidLoading || !markPaidAmount}
+                    className="flex-1 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-gray-950 font-medium text-sm py-2 rounded-lg transition-colors"
+                  >
+                    {markPaidLoading ? 'Saving…' : 'Confirm'}
+                  </button>
+                  <button
+                    onClick={() => setMarkPaidTransfer(null)}
+                    className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 font-medium text-sm py-2 rounded-lg transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
               </div>
             </div>
           )}

--- a/apps/web/src/pages/admin/AutomationsAdminPage.tsx
+++ b/apps/web/src/pages/admin/AutomationsAdminPage.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Zap } from 'lucide-react'
+import { api } from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+
+interface AutomationRun {
+  id: string
+  triggeredBy: 'SCHEDULE' | 'MANUAL'
+  triggeredByUserId: string | null
+  startedAt: string
+  finishedAt: string
+  status: 'SUCCESS' | 'ERROR' | 'SKIPPED'
+  message: string | null
+}
+
+interface Automation {
+  id: string
+  key: string
+  label: string
+  description: string
+  schedule: string
+  isEnabled: boolean
+  lastRunAt: string | null
+  lastRunStatus: 'SUCCESS' | 'ERROR' | 'SKIPPED' | null
+  household: { id: string; name: string }
+  _count: { runs: number }
+}
+
+function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return 'Never'
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'Just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+function humanSchedule(cron: string): string {
+  if (cron === '0 0 1 * *') return '1st of every month'
+  if (cron === '0 6 * * *') return 'Daily at 06:00'
+  return cron
+}
+
+function StatusBadge({ status }: { status: 'SUCCESS' | 'ERROR' | 'SKIPPED' | null }) {
+  if (!status) return <span className="text-gray-600 text-xs">Never run</span>
+  const styles = {
+    SUCCESS: 'bg-green-900/50 text-green-300',
+    ERROR: 'bg-red-900/50 text-red-300',
+    SKIPPED: 'bg-gray-800 text-gray-400',
+  }
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${styles[status]}`}>
+      {status}
+    </span>
+  )
+}
+
+export function AutomationsAdminPage() {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const [runAllLoading, setRunAllLoading] = useState(false)
+  const [triggerLoading, setTriggerLoading] = useState<string | null>(null)
+  const [runsModal, setRunsModal] = useState<{ automation: Automation; runs: AutomationRun[] } | null>(null)
+  const [runsLoading, setRunsLoading] = useState(false)
+
+  const { data: automations = [], isLoading } = useQuery<Automation[]>({
+    queryKey: ['admin', 'automations'],
+    queryFn: async () => (await api.get<Automation[]>('/admin/automations')).data,
+  })
+
+  async function handleRunAll() {
+    setRunAllLoading(true)
+    try {
+      await api.post('/admin/automations/trigger-all')
+      queryClient.invalidateQueries({ queryKey: ['admin', 'automations'] })
+    } finally {
+      setRunAllLoading(false)
+    }
+  }
+
+  async function handleToggle(automation: Automation) {
+    await api.patch(`/admin/automations/${automation.id}/toggle`)
+    queryClient.invalidateQueries({ queryKey: ['admin', 'automations'] })
+  }
+
+  async function handleTrigger(automation: Automation) {
+    setTriggerLoading(automation.id)
+    try {
+      await api.post(`/admin/automations/${automation.id}/trigger`)
+      queryClient.invalidateQueries({ queryKey: ['admin', 'automations'] })
+    } finally {
+      setTriggerLoading(null)
+    }
+  }
+
+  async function handleViewRuns(automation: Automation) {
+    setRunsLoading(true)
+    try {
+      const res = await api.get<AutomationRun[]>(`/admin/automations/${automation.id}/runs`)
+      setRunsModal({ automation, runs: res.data })
+    } finally {
+      setRunsLoading(false)
+    }
+  }
+
+  if (!user || user.role !== 'SYSTEM_ADMIN') {
+    return <div className="p-8 text-red-400">Access denied.</div>
+  }
+
+  return (
+    <main className="max-w-6xl mx-auto px-6 py-8">
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold mb-1 flex items-center gap-2">
+            <Zap size={20} className="text-amber-400" />
+            Automations
+          </h1>
+          <p className="text-gray-400 text-sm">Manage scheduled background automations across all households.</p>
+        </div>
+        <button
+          onClick={handleRunAll}
+          disabled={runAllLoading}
+          className="bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-gray-950 font-medium text-sm px-4 py-2 rounded-lg transition-colors"
+        >
+          {runAllLoading ? 'Running…' : 'Run All'}
+        </button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-gray-500">Loading…</p>
+      ) : automations.length === 0 ? (
+        <p className="text-gray-600 text-sm">No automations registered.</p>
+      ) : (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-800 text-gray-400 text-left">
+                <th className="px-4 py-3 font-medium">Household</th>
+                <th className="px-4 py-3 font-medium">Automation</th>
+                <th className="px-4 py-3 font-medium">Schedule</th>
+                <th className="px-4 py-3 font-medium">Last Run</th>
+                <th className="px-4 py-3 font-medium">Enabled</th>
+                <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {automations.map((a) => (
+                <tr key={a.id} className="border-b border-gray-800 last:border-0 hover:bg-gray-800/40">
+                  <td className="px-4 py-3 text-white">{a.household.name}</td>
+                  <td className="px-4 py-3">
+                    <div className="text-white">{a.label}</div>
+                    <div className="text-gray-500 text-xs mt-0.5">{a.description}</div>
+                  </td>
+                  <td className="px-4 py-3 text-gray-400">{humanSchedule(a.schedule)}</td>
+                  <td className="px-4 py-3">
+                    <div className="text-gray-400 text-xs mb-1">{relativeTime(a.lastRunAt)}</div>
+                    <StatusBadge status={a.lastRunStatus} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => handleToggle(a)}
+                      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                        a.isEnabled ? 'bg-amber-500' : 'bg-gray-700'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                          a.isEnabled ? 'translate-x-4' : 'translate-x-1'
+                        }`}
+                      />
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <button
+                        onClick={() => handleTrigger(a)}
+                        disabled={triggerLoading === a.id}
+                        className="text-amber-400 hover:text-amber-300 disabled:opacity-50 text-xs font-medium transition-colors"
+                      >
+                        {triggerLoading === a.id ? 'Running…' : 'Trigger Now'}
+                      </button>
+                      <button
+                        onClick={() => handleViewRuns(a)}
+                        disabled={runsLoading}
+                        className="text-gray-400 hover:text-white text-xs transition-colors"
+                      >
+                        View runs ({a._count.runs})
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Run history modal */}
+      {runsModal && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 px-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 w-full max-w-2xl max-h-[80vh] flex flex-col">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-white">
+                Run History — {runsModal.automation.label}
+              </h3>
+              <button
+                onClick={() => setRunsModal(null)}
+                className="text-gray-400 hover:text-white text-xl leading-none"
+              >
+                ×
+              </button>
+            </div>
+            <div className="overflow-y-auto flex-1">
+              {runsModal.runs.length === 0 ? (
+                <p className="text-gray-600 text-sm text-center py-8">No runs recorded yet.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-gray-400 text-left border-b border-gray-800">
+                      <th className="pb-2 font-medium">Started</th>
+                      <th className="pb-2 font-medium">Triggered by</th>
+                      <th className="pb-2 font-medium">Status</th>
+                      <th className="pb-2 font-medium">Message</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {runsModal.runs.map((r) => (
+                      <tr key={r.id} className="border-b border-gray-800 last:border-0">
+                        <td className="py-2 text-gray-400 text-xs tabular-nums">
+                          {new Date(r.startedAt).toLocaleString()}
+                        </td>
+                        <td className="py-2 text-gray-400 text-xs">{r.triggeredBy}</td>
+                        <td className="py-2"><StatusBadge status={r.status} /></td>
+                        <td className="py-2 text-gray-500 text-xs truncate max-w-xs" title={r.message ?? ''}>
+                          {r.message ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/prisma/migrations/20260403000000_add_automations_and_budget_transfers/migration.sql
+++ b/prisma/migrations/20260403000000_add_automations_and_budget_transfers/migration.sql
@@ -1,0 +1,72 @@
+-- CreateEnum
+CREATE TYPE "AutomationTrigger" AS ENUM ('SCHEDULE', 'MANUAL');
+
+-- CreateEnum
+CREATE TYPE "AutomationRunStatus" AS ENUM ('SUCCESS', 'ERROR', 'SKIPPED');
+
+-- CreateEnum
+CREATE TYPE "TransferStatus" AS ENUM ('PENDING', 'PAID', 'ADJUSTED');
+
+-- CreateTable
+CREATE TABLE "Automation" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "schedule" TEXT NOT NULL,
+    "householdId" TEXT NOT NULL,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "lastRunAt" TIMESTAMP(3),
+    "lastRunStatus" "AutomationRunStatus",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Automation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AutomationRun" (
+    "id" TEXT NOT NULL,
+    "automationId" TEXT NOT NULL,
+    "triggeredBy" "AutomationTrigger" NOT NULL,
+    "triggeredByUserId" TEXT,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "finishedAt" TIMESTAMP(3) NOT NULL,
+    "status" "AutomationRunStatus" NOT NULL,
+    "message" TEXT,
+
+    CONSTRAINT "AutomationRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BudgetTransfer" (
+    "id" TEXT NOT NULL,
+    "budgetYearId" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "month" INTEGER NOT NULL,
+    "calculatedAmount" DECIMAL(10,2) NOT NULL,
+    "actualAmount" DECIMAL(10,2),
+    "status" "TransferStatus" NOT NULL DEFAULT 'PENDING',
+    "calculatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "paidAt" TIMESTAMP(3),
+    "automationRunId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BudgetTransfer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Automation_householdId_key_key" ON "Automation"("householdId", "key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BudgetTransfer_budgetYearId_month_year_key" ON "BudgetTransfer"("budgetYearId", "month", "year");
+
+-- AddForeignKey
+ALTER TABLE "Automation" ADD CONSTRAINT "Automation_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AutomationRun" ADD CONSTRAINT "AutomationRun_automationId_fkey" FOREIGN KEY ("automationId") REFERENCES "Automation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BudgetTransfer" ADD CONSTRAINT "BudgetTransfer_budgetYearId_fkey" FOREIGN KEY ("budgetYearId") REFERENCES "BudgetYear"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,23 @@ enum AccountType {
   MOBILE_PAY
 }
 
+enum AutomationTrigger {
+  SCHEDULE
+  MANUAL
+}
+
+enum AutomationRunStatus {
+  SUCCESS
+  ERROR
+  SKIPPED
+}
+
+enum TransferStatus {
+  PENDING
+  PAID
+  ADJUSTED
+}
+
 model User {
   id                        String                     @id @default(cuid())
   email                     String                     @unique
@@ -113,6 +130,7 @@ model Household {
   members     HouseholdMember[]
   budgetYears BudgetYear[]
   accounts    Account[]
+  automations Automation[]
 }
 
 model HouseholdMember {
@@ -143,6 +161,7 @@ model BudgetYear {
   expenses        Expense[]
   savingsEntries  SavingsEntry[]
   incomeAllocations HouseholdIncomeAllocation[]
+  transfers       BudgetTransfer[]
 }
 
 model Job {
@@ -354,4 +373,52 @@ model RefreshToken {
   userId    String
   expiresAt DateTime
   createdAt DateTime @default(now())
+}
+
+model Automation {
+  id            String               @id @default(cuid())
+  key           String
+  label         String
+  description   String
+  schedule      String
+  householdId   String
+  household     Household            @relation(fields: [householdId], references: [id])
+  isEnabled     Boolean              @default(true)
+  lastRunAt     DateTime?
+  lastRunStatus AutomationRunStatus?
+  runs          AutomationRun[]
+  createdAt     DateTime             @default(now())
+  updatedAt     DateTime             @updatedAt
+
+  @@unique([householdId, key])
+}
+
+model AutomationRun {
+  id                String               @id @default(cuid())
+  automationId      String
+  automation        Automation           @relation(fields: [automationId], references: [id])
+  triggeredBy       AutomationTrigger
+  triggeredByUserId String?
+  startedAt         DateTime
+  finishedAt        DateTime
+  status            AutomationRunStatus
+  message           String?
+}
+
+model BudgetTransfer {
+  id               String         @id @default(cuid())
+  budgetYearId     String
+  budgetYear       BudgetYear     @relation(fields: [budgetYearId], references: [id])
+  year             Int
+  month            Int
+  calculatedAmount Decimal        @db.Decimal(10, 2)
+  actualAmount     Decimal?       @db.Decimal(10, 2)
+  status           TransferStatus @default(PENDING)
+  calculatedAt     DateTime       @default(now())
+  paidAt           DateTime?
+  automationRunId  String?
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+
+  @@unique([budgetYearId, month, year])
 }


### PR DESCRIPTION
Introduces the BudgetTransfer system so expense changes never spread
backwards into past months. Every expense/savings write recalculates
the current month's pending transfer using the forward-looking formula:
max(0, (annualNeed - alreadyPaid) / remainingMonths).

Schema (#133):
- Add Automation, AutomationRun, BudgetTransfer models
- Add AutomationTrigger, AutomationRunStatus, TransferStatus enums
- @@unique([householdId, key]) on Automation (compound, not global)

Calculation helper (#134):
- calcForwardMonthlyNeed() in calculations.ts
- 8 unit tests covering Jan/Jul/Dec, paid transfers, edge cases

Recalculation service (#135):
- apps/api/src/lib/budgetTransfer.ts: recalculateTransfer()
- ACTIVE-only, skips FUTURE/RETIRED/SIMULATION budget years
- PAID/ADJUSTED current month → writes to next month's row (AC4)
- Wired fire-and-forget into expenses POST/PUT/DELETE and savings POST/PUT/DELETE

Automation runner + cron (#136):
- apps/api/src/lib/automations.ts: runAutomation(), runAllEnabledAutomations()
- Monthly cron (0 0 1 * *) registered in index.ts
- Automation row seeded on household create
- SUCCESS/ERROR/SKIPPED AutomationRun logging with lastRunAt denormalisation

Budget transfers REST API (#137):
- GET /budget-years/:id/transfers
- PATCH .../mark-paid (PAID vs ADJUSTED based on actualAmount match)
- PATCH .../mark-pending (revert)

Admin automations REST API (#138):
- GET/PATCH/POST /admin/automations (list, toggle, trigger, trigger-all, run history)
- All routes require SYSTEM_ADMIN

Frontend (#139, #140):
- apps/web/src/hooks/useTransfers.ts
- DashboardPage: transfer tile, mark-as-paid modal, collapsible history table
- AutomationsAdminPage with run-history modal and enable toggle
- /admin/automations route + nav link in AdminLayout

https://claude.ai/code/session_01AzqKgp6khNtsr68Dh4tpNn