### PR TITLE
feat: bulk edit expenses and savings (#144)

### DIFF
--- a/apps/api/src/routes/expenses.ts
+++ b/apps/api/src/routes/expenses.ts
@@ -45,6 +45,15 @@ const UpdateExpenseSchema = ExpenseBaseSchema.partial()
   .refine((d) => Object.keys(d).length > 0, { message: 'At least one field is required' })
   .refine(monthRangeRefinement, { message: 'startMonth must be ≤ endMonth', path: ['endMonth'] })
 
+const BulkUpdateExpenseSchema = z.object({
+  ids: z.array(z.string()).min(1, { message: 'At least one expense ID required' }),
+  categoryId: z.string().optional(),
+  accountId: z.string().nullable().optional(),
+}).refine(
+  (d) => d.categoryId !== undefined || d.accountId !== undefined,
+  { message: 'At least one field to update is required' }
+)
+
 const expenseInclude = {
   category: { select: { id: true, name: true, icon: true, isSystemWide: true, categoryType: true } },
   ownedBy: { select: { id: true, name: true } },
@@ -259,6 +268,45 @@ export async function expenseRoutes(fastify: FastifyInstance) {
 
     recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.send(expense)
+  })
+
+  // PATCH /budget-years/:id/expenses/bulk
+  fastify.patch('/budget-years/:id/expenses/bulk', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const result = BulkUpdateExpenseSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+
+    const { ids, categoryId, accountId } = result.data
+
+    if (categoryId !== undefined) {
+      const category = await prisma.category.findUnique({ where: { id: categoryId } })
+      if (!category) return reply.status(400).send({ error: 'Category not found' })
+    }
+
+    if (accountId !== undefined && accountId !== null) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
+    }
+
+    const { count } = await prisma.expense.updateMany({
+      where: { id: { in: ids }, budgetYearId: id },
+      data: {
+        ...(categoryId !== undefined && { categoryId }),
+        ...(accountId !== undefined && { accountId }),
+      },
+    })
+
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
+    return reply.send({ updated: count })
   })
 
   // DELETE /budget-years/:id/expenses/:expenseId

--- a/apps/api/src/routes/savings.ts
+++ b/apps/api/src/routes/savings.ts
@@ -37,6 +37,15 @@ const UpdateSavingsSchema = CreateSavingsSchema.partial().refine(
   { message: 'At least one field is required' }
 )
 
+const BulkUpdateSavingsSchema = z.object({
+  ids: z.array(z.string()).min(1, { message: 'At least one savings ID required' }),
+  categoryId: z.string().nullable().optional(),
+  accountId: z.string().nullable().optional(),
+}).refine(
+  (d) => d.categoryId !== undefined || d.accountId !== undefined,
+  { message: 'At least one field to update is required' }
+)
+
 const savingsInclude = {
   category: { select: { id: true, name: true, icon: true, categoryType: true } },
   ownedBy: { select: { id: true, name: true } },
@@ -229,6 +238,46 @@ export async function savingsRoutes(fastify: FastifyInstance) {
 
     recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
     return reply.send(updated)
+  })
+
+  // PATCH /budget-years/:id/savings/bulk
+  fastify.patch('/budget-years/:id/savings/bulk', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const result = BulkUpdateSavingsSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const budgetYear = await assertBudgetYearAccess(id, userId, role === 'SYSTEM_ADMIN')
+    if (!budgetYear) return reply.status(403).send({ error: 'Forbidden' })
+    if (budgetYear.status === 'RETIRED') return reply.status(400).send({ error: 'Retired budget years are read-only' })
+
+    const { ids, categoryId, accountId } = result.data
+
+    if (categoryId !== undefined && categoryId !== null) {
+      const category = await prisma.category.findUnique({ where: { id: categoryId } })
+      if (!category) return reply.status(400).send({ error: 'Category not found' })
+    }
+
+    if (accountId !== undefined && accountId !== null) {
+      const acct = await prisma.account.findUnique({ where: { id: accountId } })
+      if (!acct || !acct.isActive) return reply.status(400).send({ error: 'Account not found' })
+      if (acct.ownedByUserId !== userId && acct.householdId !== budgetYear.householdId)
+        return reply.status(400).send({ error: 'Account not accessible' })
+    }
+
+    const { count } = await prisma.savingsEntry.updateMany({
+      where: { id: { in: ids }, budgetYearId: id },
+      data: {
+        ...(categoryId !== undefined && { categoryId }),
+        ...(accountId !== undefined && { accountId }),
+      },
+    })
+
+    recalculateTransfer(id).catch((err) => fastify.log.error({ err }, 'recalculateTransfer failed'))
+    return reply.send({ updated: count })
   })
 
   // DELETE /budget-years/:id/savings/:entryId

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -182,6 +182,12 @@ export function ExpensesPage() {
   const [form, setForm] = useState<ExpenseForm>(emptyForm('DKK'))
   const [formError, setFormError] = useState('')
 
+  // Bulk edit state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkEditOpen, setBulkEditOpen] = useState(false)
+  const [bulkForm, setBulkForm] = useState<{ categoryId: string; accountId: string }>({ categoryId: '', accountId: '' })
+  const [bulkError, setBulkError] = useState('')
+
   // ── Queries ──────────────────────────────────────────────────────────────────
 
   const { data: budgetYears = [], isLoading: yearsLoading } = useQuery<BudgetYear[]>({
@@ -346,6 +352,23 @@ export function ExpensesPage() {
     },
   })
 
+  const bulkUpdateMutation = useMutation({
+    mutationFn: (payload: { ids: string[]; categoryId?: string; accountId?: string | null }) =>
+      api.patch(`/budget-years/${activeBudgetYear!.id}/expenses/bulk`, payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['expenses', activeBudgetYear?.id] })
+      setBulkEditOpen(false)
+      setSelectedIds(new Set())
+      setBulkForm({ categoryId: '', accountId: '' })
+      setBulkError('')
+      toast.success(`${variables.ids.length} expense${variables.ids.length !== 1 ? 's' : ''} updated`)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setBulkError((err.response?.data as { error?: string })?.error ?? 'Failed to update')
+    },
+  })
+
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   function openAdd() {
@@ -377,6 +400,45 @@ export function ExpensesPage() {
   function handleSort(key: SortKey) {
     if (sortKey === key) setSortAsc((a) => !a)
     else { setSortKey(key); setSortAsc(true) }
+  }
+
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (filtered.every((e) => selectedIds.has(e.id))) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        filtered.forEach((e) => next.delete(e.id))
+        return next
+      })
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        filtered.forEach((e) => next.add(e.id))
+        return next
+      })
+    }
+  }
+
+  function handleBulkSubmit(e: FormEvent) {
+    e.preventDefault()
+    setBulkError('')
+    if (!bulkForm.categoryId && !bulkForm.accountId) {
+      setBulkError('Select at least one field to change')
+      return
+    }
+    const payload: { ids: string[]; categoryId?: string; accountId?: string | null } = {
+      ids: [...selectedIds],
+    }
+    if (bulkForm.categoryId) payload.categoryId = bulkForm.categoryId
+    if (bulkForm.accountId) payload.accountId = bulkForm.accountId === '__none__' ? null : bulkForm.accountId
+    bulkUpdateMutation.mutate(payload)
   }
 
   function handleSubmit(e: FormEvent) {
@@ -519,6 +581,25 @@ export function ExpensesPage() {
               </div>
             </div>
 
+            {/* Bulk action bar */}
+            {selectedIds.size > 0 && (
+              <div className="flex items-center gap-3 bg-amber-400/10 border border-amber-400/30 rounded-lg px-4 py-2.5 mb-3">
+                <span className="text-amber-400 text-sm font-medium">{selectedIds.size} selected</span>
+                <button
+                  onClick={() => { setBulkForm({ categoryId: '', accountId: '' }); setBulkError(''); setBulkEditOpen(true) }}
+                  className="text-sm bg-amber-400 text-gray-950 font-semibold px-3 py-1 rounded-lg hover:bg-amber-300 transition-colors"
+                >
+                  Edit selected
+                </button>
+                <button
+                  onClick={() => setSelectedIds(new Set())}
+                  className="text-xs text-gray-400 hover:text-white transition-colors ml-auto"
+                >
+                  Clear selection
+                </button>
+              </div>
+            )}
+
             {/* Table / Calendar */}
             {expensesLoading ? (
               <PageLoader />
@@ -533,6 +614,16 @@ export function ExpensesPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-gray-800 text-gray-400 text-left select-none">
+                      <th className="pl-4 pr-2 py-3 w-8">
+                        <input
+                          type="checkbox"
+                          checked={filtered.length > 0 && filtered.every((e) => selectedIds.has(e.id))}
+                          ref={(el) => { if (el) el.indeterminate = filtered.some((e) => selectedIds.has(e.id)) && !filtered.every((e) => selectedIds.has(e.id)) }}
+                          onChange={toggleSelectAll}
+                          className="accent-amber-400 cursor-pointer"
+                          aria-label="Select all"
+                        />
+                      </th>
                       <th className="px-4 py-3 font-medium">
                         <button onClick={() => handleSort('label')} className="hover:text-white flex items-center">
                           Label <SortIcon col="label" />
@@ -567,7 +658,16 @@ export function ExpensesPage() {
                       const isPast = e.endMonth != null && e.endMonth < currentMonth
                       const rangeLabel = monthRangeLabel(e.startMonth, e.endMonth)
                       return (
-                      <tr key={e.id} className={`border-b border-gray-800 last:border-0 hover:bg-gray-800/40 group${isPast ? ' opacity-50' : ''}`}>
+                      <tr key={e.id} className={`border-b border-gray-800 last:border-0 hover:bg-gray-800/40 group${isPast ? ' opacity-50' : ''}${selectedIds.has(e.id) ? ' bg-amber-400/5' : ''}`}>
+                        <td className="pl-4 pr-2 py-3 w-8">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.has(e.id)}
+                            onChange={() => toggleSelect(e.id)}
+                            className="accent-amber-400 cursor-pointer"
+                            aria-label={`Select ${e.label}`}
+                          />
+                        </td>
                         <td className="px-4 py-3 text-white">
                           <div className="flex items-center gap-2 flex-wrap">
                             {e.label}
@@ -640,7 +740,7 @@ export function ExpensesPage() {
                   </tbody>
                   <tfoot>
                     <tr className="border-t border-gray-700 bg-gray-800/50">
-                      <td colSpan={4} className="px-4 py-3 text-sm text-gray-400 font-medium">
+                      <td colSpan={5} className="px-4 py-3 text-sm text-gray-400 font-medium">
                         Total{(filterCategories.size > 0 || filterAccounts.size > 0) ? ' (filtered)' : ''} — {filtered.length} {filtered.length === 1 ? 'expense' : 'expenses'}
                       </td>
                       <td className="px-4 py-3 text-right text-amber-400 font-bold tabular-nums">
@@ -923,6 +1023,78 @@ export function ExpensesPage() {
               </div>
             </form>
           </div>
+        </Modal>
+      )}
+
+      {/* Bulk edit modal */}
+      {bulkEditOpen && (
+        <Modal
+          title={`Edit ${selectedIds.size} expense${selectedIds.size !== 1 ? 's' : ''}`}
+          onClose={() => setBulkEditOpen(false)}
+          size="sm"
+        >
+          <p className="text-xs text-gray-500 mb-4">Only fields you change will be updated. Leave a field as "— unchanged —" to keep existing values.</p>
+          <form onSubmit={handleBulkSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Category</label>
+              <select
+                value={bulkForm.categoryId}
+                onChange={(e) => setBulkForm({ ...bulkForm, categoryId: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— unchanged —</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>{c.name}{c.isSystemWide ? '' : ' (custom)'}</option>
+                ))}
+              </select>
+            </div>
+            {hasAccounts && (
+              <div>
+                <label className="block text-xs font-medium text-gray-400 mb-1">Account</label>
+                <select
+                  value={bulkForm.accountId}
+                  onChange={(e) => setBulkForm({ ...bulkForm, accountId: e.target.value })}
+                  className={inputClass}
+                >
+                  <option value="">— unchanged —</option>
+                  <option value="__none__">None (clear account)</option>
+                  {personalAccounts.length > 0 && (
+                    <optgroup label="My accounts">
+                      {personalAccounts.map((a) => (
+                        <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {householdAccountOptions.length > 0 && (
+                    <optgroup label="Household accounts">
+                      {householdAccountOptions.map((a) => (
+                        <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                      ))}
+                    </optgroup>
+                  )}
+                </select>
+              </div>
+            )}
+            {bulkError && (
+              <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">{bulkError}</div>
+            )}
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={bulkUpdateMutation.isPending}
+                className="flex-1 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                {bulkUpdateMutation.isPending ? 'Saving…' : 'Apply changes'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setBulkEditOpen(false)}
+                className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
         </Modal>
       )}
 

--- a/apps/web/src/pages/SavingsPage.tsx
+++ b/apps/web/src/pages/SavingsPage.tsx
@@ -139,6 +139,12 @@ export function SavingsPage() {
   const [formError, setFormError] = useState('')
   const [filterAccounts, setFilterAccounts] = useState<Set<string>>(new Set())
 
+  // Bulk edit state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkEditOpen, setBulkEditOpen] = useState(false)
+  const [bulkForm, setBulkForm] = useState<{ categoryId: string; accountId: string }>({ categoryId: '', accountId: '' })
+  const [bulkError, setBulkError] = useState('')
+
   // ── Queries ──────────────────────────────────────────────────────────────────
 
   const { data: budgetYears = [], isLoading: yearsLoading } = useQuery<BudgetYear[]>({
@@ -298,6 +304,23 @@ export function SavingsPage() {
     },
   })
 
+  const bulkUpdateMutation = useMutation({
+    mutationFn: (payload: { ids: string[]; categoryId?: string | null; accountId?: string | null }) =>
+      api.patch(`/budget-years/${activeBudgetYear!.id}/savings/bulk`, payload),
+    onSuccess: (_data, variables) => {
+      invalidate()
+      setBulkEditOpen(false)
+      setSelectedIds(new Set())
+      setBulkForm({ categoryId: '', accountId: '' })
+      setBulkError('')
+      toast.success(`${variables.ids.length} entr${variables.ids.length !== 1 ? 'ies' : 'y'} updated`)
+    },
+    onError: (err) => {
+      if (axios.isAxiosError(err))
+        setBulkError((err.response?.data as { error?: string })?.error ?? 'Failed to update')
+    },
+  })
+
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
   function openAdd() { setForm(emptyForm(baseCurrency)); setFormError(''); setShowAdd(true) }
@@ -319,6 +342,45 @@ export function SavingsPage() {
     setEditingEntry(e)
   }
 
+  function toggleSelect(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (filteredEntries.every((e) => selectedIds.has(e.id))) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        filteredEntries.forEach((e) => next.delete(e.id))
+        return next
+      })
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        filteredEntries.forEach((e) => next.add(e.id))
+        return next
+      })
+    }
+  }
+
+  function handleBulkSubmit(e: FormEvent) {
+    e.preventDefault()
+    setBulkError('')
+    if (!bulkForm.categoryId && !bulkForm.accountId) {
+      setBulkError('Select at least one field to change')
+      return
+    }
+    const payload: { ids: string[]; categoryId?: string | null; accountId?: string | null } = {
+      ids: [...selectedIds],
+    }
+    if (bulkForm.categoryId) payload.categoryId = bulkForm.categoryId === '__none__' ? null : bulkForm.categoryId
+    if (bulkForm.accountId) payload.accountId = bulkForm.accountId === '__none__' ? null : bulkForm.accountId
+    bulkUpdateMutation.mutate(payload)
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setFormError('')
@@ -337,7 +399,7 @@ export function SavingsPage() {
 
   // ── Render ────────────────────────────────────────────────────────────────────
 
-  const colSpan = isReadOnly ? 5 : 6
+  const colSpan = isReadOnly ? 5 : 7
 
   return (
     <>
@@ -434,10 +496,40 @@ export function SavingsPage() {
             )}
           </div>
         ) : (
+          <>
+          {selectedIds.size > 0 && !isReadOnly && (
+            <div className="flex items-center gap-3 bg-amber-400/10 border border-amber-400/30 rounded-lg px-4 py-2.5 mb-3">
+              <span className="text-amber-400 text-sm font-medium">{selectedIds.size} selected</span>
+              <button
+                onClick={() => { setBulkForm({ categoryId: '', accountId: '' }); setBulkError(''); setBulkEditOpen(true) }}
+                className="text-sm bg-amber-400 text-gray-950 font-semibold px-3 py-1 rounded-lg hover:bg-amber-300 transition-colors"
+              >
+                Edit selected
+              </button>
+              <button
+                onClick={() => setSelectedIds(new Set())}
+                className="text-xs text-gray-400 hover:text-white transition-colors ml-auto"
+              >
+                Clear selection
+              </button>
+            </div>
+          )}
           <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
+                  {!isReadOnly && (
+                    <th className="pl-4 pr-2 py-3 w-8">
+                      <input
+                        type="checkbox"
+                        checked={filteredEntries.length > 0 && filteredEntries.every((e) => selectedIds.has(e.id))}
+                        ref={(el) => { if (el) el.indeterminate = filteredEntries.some((e) => selectedIds.has(e.id)) && !filteredEntries.every((e) => selectedIds.has(e.id)) }}
+                        onChange={toggleSelectAll}
+                        className="accent-amber-400 cursor-pointer"
+                        aria-label="Select all"
+                      />
+                    </th>
+                  )}
                   <th className="px-4 py-3 font-medium">Label</th>
                   <th className="px-4 py-3 font-medium">Category</th>
                   <th className="px-4 py-3 font-medium">Frequency</th>
@@ -448,7 +540,18 @@ export function SavingsPage() {
               </thead>
               <tbody>
                 {filteredEntries.map((e) => (
-                  <tr key={e.id} className="border-b border-gray-800 last:border-0 hover:bg-gray-800/40 group">
+                  <tr key={e.id} className={`border-b border-gray-800 last:border-0 hover:bg-gray-800/40 group${selectedIds.has(e.id) ? ' bg-amber-400/5' : ''}`}>
+                    {!isReadOnly && (
+                      <td className="pl-4 pr-2 py-3 w-8">
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(e.id)}
+                          onChange={() => toggleSelect(e.id)}
+                          className="accent-amber-400 cursor-pointer"
+                          aria-label={`Select ${e.label}`}
+                        />
+                      </td>
+                    )}
                     <td className="px-4 py-3 text-white">
                       <div className="flex items-center gap-2 flex-wrap">
                         {e.label}
@@ -515,6 +618,7 @@ export function SavingsPage() {
               </tfoot>
             </table>
           </div>
+          </>
         )}
       </main>
 
@@ -747,6 +851,81 @@ export function SavingsPage() {
               </div>
             </form>
           </div>
+        </Modal>
+      )}
+
+      {/* Bulk edit modal */}
+      {bulkEditOpen && (
+        <Modal
+          title={`Edit ${selectedIds.size} entr${selectedIds.size !== 1 ? 'ies' : 'y'}`}
+          onClose={() => setBulkEditOpen(false)}
+          size="sm"
+        >
+          <p className="text-xs text-gray-500 mb-4">Only fields you change will be updated. Leave a field as "— unchanged —" to keep existing values.</p>
+          <form onSubmit={handleBulkSubmit} className="space-y-4">
+            {savingsCategories.length > 0 && (
+              <div>
+                <label className="block text-xs font-medium text-gray-400 mb-1">Category</label>
+                <select
+                  value={bulkForm.categoryId}
+                  onChange={(e) => setBulkForm({ ...bulkForm, categoryId: e.target.value })}
+                  className={inputClass}
+                >
+                  <option value="">— unchanged —</option>
+                  <option value="__none__">None (clear category)</option>
+                  {savingsCategories.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}{c.isSystemWide ? '' : ' (custom)'}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {hasAccounts && (
+              <div>
+                <label className="block text-xs font-medium text-gray-400 mb-1">Account</label>
+                <select
+                  value={bulkForm.accountId}
+                  onChange={(e) => setBulkForm({ ...bulkForm, accountId: e.target.value })}
+                  className={inputClass}
+                >
+                  <option value="">— unchanged —</option>
+                  <option value="__none__">None (clear account)</option>
+                  {personalAccounts.length > 0 && (
+                    <optgroup label="My accounts">
+                      {personalAccounts.map((a) => (
+                        <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {householdAccountOptions.length > 0 && (
+                    <optgroup label="Household accounts">
+                      {householdAccountOptions.map((a) => (
+                        <option key={a.id} value={a.id}>{a.name} ({ACCOUNT_TYPE_LABELS[a.type]})</option>
+                      ))}
+                    </optgroup>
+                  )}
+                </select>
+              </div>
+            )}
+            {bulkError && (
+              <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">{bulkError}</div>
+            )}
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={bulkUpdateMutation.isPending}
+                className="flex-1 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                {bulkUpdateMutation.isPending ? 'Saving…' : 'Apply changes'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setBulkEditOpen(false)}
+                className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
         </Modal>
       )}
 


### PR DESCRIPTION
Allows users to select multiple expense or savings rows and update
their category and/or account in a single operation, avoiding
repetitive one-by-one edits.

- Add PATCH /budget-years/:id/expenses/bulk endpoint
- Add PATCH /budget-years/:id/savings/bulk endpoint
- Checkbox column in expense and savings tables with select-all support
- Amber-styled bulk action bar appears when rows are selected
- Bulk edit modal with category and account fields (leave unchanged or clear)

https://claude.ai/code/session_011REEaWUTBuw487NnYMLKHg