### PR TITLE
fix: use UTC-based refDate in income/trend to avoid timezone gap

### DIFF
--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -125,7 +125,7 @@ export async function profileRoutes(fastify: FastifyInstance) {
     const jobTrends = jobs.map((job) => {
       const monthly: number[] = months.map((monthStr) => {
         const [year, mon] = monthStr.split('-').map(Number)
-        const refDate = new Date(year, mon - 1, 1)
+        const refDate = new Date(Date.UTC(year, mon - 1, 1))
 
         if (job.startDate > new Date(year, mon - 1, 28)) return 0
         if (job.endDate && job.endDate < refDate) return 0
@@ -145,7 +145,7 @@ export async function profileRoutes(fastify: FastifyInstance) {
 
       const monthlyNet: number[] = months.map((monthStr) => {
         const [year, mon] = monthStr.split('-').map(Number)
-        const refDate = new Date(year, mon - 1, 1)
+        const refDate = new Date(Date.UTC(year, mon - 1, 1))
 
         if (job.startDate > new Date(year, mon - 1, 28)) return 0
         if (job.endDate && job.endDate < refDate) return 0


### PR DESCRIPTION
When the server runs in a UTC+ timezone (e.g. Denmark UTC+1/+2),
`new Date(year, mon - 1, 1)` creates local midnight which is behind
UTC midnight. Salary `effectiveFrom` dates are stored as UTC midnight
(from ISO string parsing), so the filter `effectiveFrom <= refDate`
would fail for salaries starting on the 1st of a month — the new
job's salary was never found, returning 0 and causing the graph dip.

Fix: use `new Date(Date.UTC(year, mon - 1, 1))` for refDate so
the comparison is UTC-consistent in all timezones.

https://claude.ai/code/session_01ErJTVgqnDNDQWjqXUyYw4T