### PR TITLE
fix: show actual per-period monthly cost on expenses page

### DIFF
--- a/apps/api/src/routes/expenses.ts
+++ b/apps/api/src/routes/expenses.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { Decimal } from '@prisma/client/runtime/client'
 import { prisma } from '../lib/prisma'
 import { authenticate } from '../plugins/authenticate'
-import { calcMonthlyEquivalent, calcAnnualAverage } from '../lib/calculations'
+import { calcMonthlyEquivalent, calcAnnualAverage, activeMonthCount } from '../lib/calculations'
 import { getLatestRate, BASE_CURRENCY } from '../lib/currency'
 import { assertBudgetYearAccess, validateOwnership } from '../lib/ownership'
 import { toNum } from '../lib/decimal'
@@ -77,7 +77,13 @@ export async function expenseRoutes(fastify: FastifyInstance) {
       orderBy: [{ category: { name: 'asc' } }, { label: 'asc' }],
     })
 
-    return reply.send(expenses)
+    const result = expenses.map((e) => {
+      const months = activeMonthCount(e.startMonth, e.endMonth)
+      const monthlyWhenActive = new Decimal(e.monthlyEquivalent.toString()).mul(12).div(months).toDecimalPlaces(2)
+      return { ...e, monthlyWhenActive: monthlyWhenActive.toString() }
+    })
+
+    return reply.send(result)
   })
 
   // POST /budget-years/:id/expenses

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -63,6 +63,7 @@ interface Expense {
   startMonth: number | null
   endMonth: number | null
   monthlyEquivalent: string
+  monthlyWhenActive: string
   notes: string | null
   category: Category
   currencyCode: string | null
@@ -261,14 +262,14 @@ export function ExpensesPage() {
         case 'category':  cmp = a.category.name.localeCompare(b.category.name); break
         case 'amount':    cmp = parseFloat(a.amount) - parseFloat(b.amount); break
         case 'frequency': cmp = FREQ_ORDER[a.frequency] - FREQ_ORDER[b.frequency]; break
-        case 'monthly':   cmp = parseFloat(a.monthlyEquivalent) - parseFloat(b.monthlyEquivalent); break
+        case 'monthly':   cmp = parseFloat(a.monthlyWhenActive) - parseFloat(b.monthlyWhenActive); break
       }
       return sortAsc ? cmp : -cmp
     })
   }, [expenses, filterCategories, sortKey, sortAsc])
 
   const totalMonthly = useMemo(
-    () => filtered.reduce((sum, e) => sum + parseFloat(e.monthlyEquivalent), 0),
+    () => filtered.reduce((sum, e) => sum + parseFloat(e.monthlyWhenActive), 0),
     [filtered]
   )
 
@@ -717,7 +718,7 @@ export function ExpensesPage() {
                           )}
                         </td>
                         <td className="px-4 py-3 text-right text-amber-400 tabular-nums font-medium">
-                          {fmt(parseFloat(e.monthlyEquivalent))}
+                          {fmt(parseFloat(e.monthlyWhenActive))}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <div className="flex items-center justify-end gap-3 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
Previously, partial-year expenses (startMonth/endMonth set) showed their
annual-average equivalent (total ÷ 12) on the expenses list. A monthly
expense of 300 DKK active Oct–Dec would appear as 75/month instead of 300.

The GET /budget-years/:id/expenses endpoint now computes `monthlyWhenActive`
for each expense by reversing the annual-average compression:
  monthlyWhenActive = monthlyEquivalent × 12 / activeMonths

The expenses page uses this field for the /month column, total, and sort.
The stored `monthlyEquivalent` (annual average) is unchanged and continues
to drive budget transfer and dashboard calculations.

https://claude.ai/code/session_01FZaZHCQUMUFAJ2jdUL47Tg