### PR TITLE
feat: flexible budgeting models — schema foundation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,18 @@ enum TransferStatus {
   ADJUSTED
 }
 
+enum BudgetModelType {
+  AVERAGE
+  FORWARD_LOOKING
+  PAY_NO_PAY
+}
+
+enum OccurrenceStatus {
+  PENDING
+  PAID
+  SKIPPED
+}
+
 model User {
   id                        String                     @id @default(cuid())
   email                     String                     @unique
@@ -125,6 +137,7 @@ model Household {
   name                  String
   isActive              Boolean           @default(true)
   autoMarkTransferPaid  Boolean           @default(false)
+  budgetModel           BudgetModelType   @default(AVERAGE)
   createdAt             DateTime          @default(now())
   updatedAt             DateTime          @updatedAt
 
@@ -283,7 +296,8 @@ model Expense {
   frequencyPeriod   String?
   startMonth        Int?
   endMonth          Int?
-  monthlyEquivalent Decimal          @db.Decimal(10, 2)
+  monthlyEquivalent        Decimal          @db.Decimal(10, 2)
+  forwardMonthlyEquivalent Decimal?         @db.Decimal(10, 2)
   notes             String?
   currencyCode      String?
   originalAmount    Decimal?         @db.Decimal(10, 2)
@@ -295,6 +309,7 @@ model Expense {
   accountId         String?
   account           Account?         @relation(fields: [accountId], references: [id], onDelete: SetNull)
   customSplits      ExpenseCustomSplit[]
+  occurrences       ExpenseOccurrence[]
   createdAt         DateTime         @default(now())
   updatedAt         DateTime         @updatedAt
 }
@@ -318,7 +333,8 @@ model SavingsEntry {
   amount            Decimal          @db.Decimal(10, 2)
   frequency         Frequency
   frequencyPeriod   String?
-  monthlyEquivalent Decimal          @db.Decimal(10, 2)
+  monthlyEquivalent        Decimal          @db.Decimal(10, 2)
+  forwardMonthlyEquivalent Decimal?         @db.Decimal(10, 2)
   notes             String?
   currencyCode      String?
   originalAmount    Decimal?         @db.Decimal(10, 2)
@@ -332,6 +348,7 @@ model SavingsEntry {
   categoryId        String?
   category          Category?        @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   customSplits      SavingsCustomSplit[]
+  occurrences       SavingsOccurrence[]
   createdAt         DateTime         @default(now())
   updatedAt         DateTime         @updatedAt
 }
@@ -422,4 +439,40 @@ model BudgetTransfer {
   updatedAt        DateTime       @updatedAt
 
   @@unique([budgetYearId, month, year])
+}
+
+model ExpenseOccurrence {
+  id              String           @id @default(cuid())
+  expenseId       String
+  expense         Expense          @relation(fields: [expenseId], references: [id], onDelete: Cascade)
+  year            Int
+  month           Int
+  scheduledAmount Decimal          @db.Decimal(10, 2)
+  carriedAmount   Decimal          @db.Decimal(10, 2) @default(0)
+  status          OccurrenceStatus @default(PENDING)
+  paidAt          DateTime?
+  actualAmount    Decimal?         @db.Decimal(10, 2)
+  note            String?
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+
+  @@unique([expenseId, year, month])
+}
+
+model SavingsOccurrence {
+  id              String           @id @default(cuid())
+  savingsEntryId  String
+  savingsEntry    SavingsEntry     @relation(fields: [savingsEntryId], references: [id], onDelete: Cascade)
+  year            Int
+  month           Int
+  scheduledAmount Decimal          @db.Decimal(10, 2)
+  carriedAmount   Decimal          @db.Decimal(10, 2) @default(0)
+  status          OccurrenceStatus @default(PENDING)
+  paidAt          DateTime?
+  actualAmount    Decimal?         @db.Decimal(10, 2)
+  note            String?
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+
+  @@unique([savingsEntryId, year, month])
 }


### PR DESCRIPTION
## Summary

- Adds `BudgetModelType` enum (`AVERAGE`, `FORWARD_LOOKING`, `PAY_NO_PAY`) and `OccurrenceStatus` enum (`PENDING`, `PAID`, `SKIPPED`)
- `Household` gains `budgetModel` field (defaults to `AVERAGE` — fully backward-compatible)
- `Expense` and `SavingsEntry` gain nullable `forwardMonthlyEquivalent` column (populated by automation in `FORWARD_LOOKING` mode)
- New `ExpenseOccurrence` and `SavingsOccurrence` tables for `PAY_NO_PAY` mode — one row per item per month, with `scheduledAmount` + `carriedAmount` (unpaid rollover from prior month)

## How each model computes the monthly transfer

| Model | Source |
|---|---|
| `AVERAGE` | `SUM(expense.monthlyEquivalent)` — unchanged from today |
| `FORWARD_LOOKING` | `SUM(expense.forwardMonthlyEquivalent)` — recalculated monthly by automation |
| `PAY_NO_PAY` | `SUM(scheduledAmount + carriedAmount)` on PENDING occurrences for the month |

`BudgetTransfer.calculatedAmount` is always a simple SUM from whichever source matches the household's model.

## Test plan

- [ ] `npx prisma validate` passes on the updated schema
- [ ] `npm run db:migrate` applies cleanly to a dev database
- [ ] Existing households default to `AVERAGE` with no data change
- [ ] `ExpenseOccurrence` and `SavingsOccurrence` tables are created with correct unique constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)