### PR TITLE
feat: branch recalculateTransfer on budgetModel; add PAY_NO_PAY occur…

### DIFF
--- a/apps/api/src/lib/automations.ts
+++ b/apps/api/src/lib/automations.ts
@@ -1,6 +1,6 @@
 import { AutomationTrigger } from '@prisma/client'
 import { prisma } from './prisma'
-import { recalculateTransfer } from './budgetTransfer'
+import { recalculateTransfer, rolloverPayNoPayOccurrences } from './budgetTransfer'
 
 export async function runAutomation(
   automationId: string,
@@ -27,7 +27,7 @@ export async function runAutomation(
   try {
     const [activeBudgetYear, household] = await Promise.all([
       prisma.budgetYear.findFirst({ where: { householdId: automation.householdId, status: 'ACTIVE' } }),
-      prisma.household.findUnique({ where: { id: automation.householdId }, select: { autoMarkTransferPaid: true } }),
+      prisma.household.findUnique({ where: { id: automation.householdId }, select: { autoMarkTransferPaid: true, budgetModel: true } }),
     ])
 
     if (!activeBudgetYear) {
@@ -42,10 +42,13 @@ export async function runAutomation(
       return
     }
 
+    const now = new Date()
+    const prevMonth = now.getMonth() === 0 ? 12 : now.getMonth() // getMonth() is 0-indexed; prev month is 1-indexed
+    const currentMonth = now.getMonth() + 1
+    const prevYear = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear()
+    const currentYear = now.getFullYear()
+
     if (household?.autoMarkTransferPaid) {
-      const now = new Date()
-      const prevMonth = now.getMonth() === 0 ? 12 : now.getMonth() // getMonth() is 0-indexed; prev month is 1-indexed
-      const prevYear = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear()
       const prevTransfer = await prisma.budgetTransfer.findUnique({
         where: { budgetYearId_month_year: { budgetYearId: activeBudgetYear.id, month: prevMonth, year: prevYear } },
       })
@@ -55,6 +58,10 @@ export async function runAutomation(
           data: { status: 'PAID', actualAmount: prevTransfer.calculatedAmount, paidAt: now },
         })
       }
+    }
+
+    if (household?.budgetModel === 'PAY_NO_PAY') {
+      await rolloverPayNoPayOccurrences(activeBudgetYear.id, currentYear, prevMonth, currentMonth)
     }
 
     await recalculateTransfer(activeBudgetYear.id)

--- a/apps/api/src/lib/budgetTransfer.ts
+++ b/apps/api/src/lib/budgetTransfer.ts
@@ -1,18 +1,30 @@
 import { Decimal } from '@prisma/client/runtime/client'
 import { prisma } from './prisma'
-import { calcForwardMonthlyNeed } from './calculations'
+import { calcForwardMonthlyNeed, calcOccurrenceScheduledAmount, activeMonthCount } from './calculations'
 
 export async function recalculateTransfer(budgetYearId: string): Promise<void> {
-  const budgetYear = await prisma.budgetYear.findUnique({ where: { id: budgetYearId } })
+  const budgetYear = await prisma.budgetYear.findUnique({
+    where: { id: budgetYearId },
+    include: { household: { select: { budgetModel: true } } },
+  })
   if (!budgetYear || budgetYear.status !== 'ACTIVE') return
 
+  const { budgetModel } = budgetYear.household
   const currentMonth = new Date().getMonth() + 1
   const year = budgetYear.year
 
   const expenses = await prisma.expense.findMany({
     where: { budgetYearId },
-    select: { monthlyEquivalent: true, startMonth: true, endMonth: true },
+    select: { id: true, monthlyEquivalent: true, startMonth: true, endMonth: true },
   })
+
+  const existingTransfers = await prisma.budgetTransfer.findMany({ where: { budgetYearId } })
+  const byMonth = new Map(existingTransfers.map((t) => [t.month, t]))
+
+  if (budgetModel === 'PAY_NO_PAY') {
+    await recalculatePayNoPay(budgetYearId, year, currentMonth, expenses, byMonth)
+    return
+  }
 
   const annualNeed = expenses.reduce(
     (sum, e) => sum.add(new Decimal(e.monthlyEquivalent.toString()).mul(12)),
@@ -20,27 +32,68 @@ export async function recalculateTransfer(budgetYearId: string): Promise<void> {
   )
   const perMonth = annualNeed.div(12)
 
-  const existingTransfers = await prisma.budgetTransfer.findMany({ where: { budgetYearId } })
-  const byMonth = new Map(existingTransfers.map((t) => [t.month, t]))
+  if (budgetModel === 'FORWARD_LOOKING') {
+    await recalculateForwardLooking(budgetYearId, year, currentMonth, expenses, byMonth, perMonth)
+    return
+  }
 
-  // Forward amount is purely based on remaining expenses from currentMonth onwards.
-  // No deficit carry-over from past months — past transfers (paid or pending) are irrelevant.
-  const forwardAmount = calcForwardMonthlyNeed(expenses, currentMonth)
+  // AVERAGE: equal split across all 12 months, clear any stale forwardMonthlyEquivalent values
+  await prisma.expense.updateMany({
+    where: { budgetYearId, NOT: { forwardMonthlyEquivalent: null } },
+    data: { forwardMonthlyEquivalent: null },
+  })
 
   for (let m = 1; m <= 12; m++) {
     const existing = byMonth.get(m)
-
-    // Never overwrite locked months
     if (existing && (existing.status === 'PAID' || existing.status === 'ADJUSTED')) continue
 
-    let calculatedAmount: Decimal
-    if (m < currentMonth) {
-      // Past months: show the equal-split planned amount
-      calculatedAmount = perMonth
-    } else {
-      // Current and future months: same forward-looking amount for a consistent plan
-      calculatedAmount = forwardAmount
-    }
+    await prisma.budgetTransfer.upsert({
+      where: { budgetYearId_month_year: { budgetYearId, month: m, year } },
+      create: { budgetYearId, year, month: m, calculatedAmount: perMonth, calculatedAt: new Date() },
+      update: { calculatedAmount: perMonth, calculatedAt: new Date() },
+    })
+  }
+}
+
+async function recalculateForwardLooking(
+  budgetYearId: string,
+  year: number,
+  currentMonth: number,
+  expenses: { id: string; monthlyEquivalent: Decimal; startMonth: number | null; endMonth: number | null }[],
+  byMonth: Map<number, { status: string }>,
+  perMonth: Decimal,
+): Promise<void> {
+  const forwardAmount = calcForwardMonthlyNeed(expenses, currentMonth)
+  const remainingMonths = 13 - currentMonth
+
+  // Write each expense's per-active-month share of the forward need to forwardMonthlyEquivalent.
+  // Uses the same per-expense decomposition as calcForwardMonthlyNeed so that SUM equals forwardAmount.
+  await Promise.all(
+    expenses.map((e) => {
+      let fwd: Decimal
+      if (remainingMonths <= 0) {
+        fwd = new Decimal(0)
+      } else {
+        const start = Math.max(e.startMonth ?? 1, currentMonth)
+        const end = e.endMonth ?? 12
+        if (start > end) {
+          fwd = new Decimal(0) // expense ended before current month
+        } else {
+          const activeRemaining = end - start + 1
+          const totalMonths = activeMonthCount(e.startMonth, e.endMonth)
+          const monthlyWhenActive = new Decimal(e.monthlyEquivalent.toString()).mul(12).div(totalMonths)
+          fwd = monthlyWhenActive.mul(activeRemaining).div(remainingMonths)
+        }
+      }
+      return prisma.expense.update({ where: { id: e.id }, data: { forwardMonthlyEquivalent: fwd } })
+    }),
+  )
+
+  for (let m = 1; m <= 12; m++) {
+    const existing = byMonth.get(m)
+    if (existing && (existing.status === 'PAID' || existing.status === 'ADJUSTED')) continue
+
+    const calculatedAmount = m < currentMonth ? perMonth : forwardAmount
 
     await prisma.budgetTransfer.upsert({
       where: { budgetYearId_month_year: { budgetYearId, month: m, year } },
@@ -48,4 +101,201 @@ export async function recalculateTransfer(budgetYearId: string): Promise<void> {
       update: { calculatedAmount, calculatedAt: new Date() },
     })
   }
+}
+
+async function recalculatePayNoPay(
+  budgetYearId: string,
+  year: number,
+  currentMonth: number,
+  expenses: { id: string; monthlyEquivalent: Decimal; startMonth: number | null; endMonth: number | null }[],
+  byMonth: Map<number, { status: string }>,
+): Promise<void> {
+  // Ensure the current month has occurrence rows for every active expense/savings entry
+  await seedCurrentMonthOccurrences(budgetYearId, year, currentMonth, expenses)
+
+  // Aggregate PENDING obligations per month from occurrence tables
+  const [expOccs, savOccs] = await Promise.all([
+    prisma.expenseOccurrence.findMany({
+      where: { expense: { budgetYearId }, year, status: 'PENDING' },
+      select: { month: true, scheduledAmount: true, carriedAmount: true },
+    }),
+    prisma.savingsOccurrence.findMany({
+      where: { savingsEntry: { budgetYearId }, year, status: 'PENDING' },
+      select: { month: true, scheduledAmount: true, carriedAmount: true },
+    }),
+  ])
+
+  const occByMonth = new Map<number, Decimal>()
+  for (const occ of [...expOccs, ...savOccs]) {
+    const prev = occByMonth.get(occ.month) ?? new Decimal(0)
+    occByMonth.set(
+      occ.month,
+      prev
+        .add(new Decimal(occ.scheduledAmount.toString()))
+        .add(new Decimal(occ.carriedAmount.toString())),
+    )
+  }
+
+  for (let m = 1; m <= 12; m++) {
+    const existing = byMonth.get(m)
+    if (existing && (existing.status === 'PAID' || existing.status === 'ADJUSTED')) continue
+
+    const calculatedAmount = occByMonth.get(m) ?? new Decimal(0)
+
+    await prisma.budgetTransfer.upsert({
+      where: { budgetYearId_month_year: { budgetYearId, month: m, year } },
+      create: { budgetYearId, year, month: m, calculatedAmount, calculatedAt: new Date() },
+      update: { calculatedAmount, calculatedAt: new Date() },
+    })
+  }
+}
+
+/** Creates occurrence rows for the current month for any expense/savings entry that lacks one. */
+async function seedCurrentMonthOccurrences(
+  budgetYearId: string,
+  year: number,
+  month: number,
+  expenses: { id: string; monthlyEquivalent: Decimal; startMonth: number | null; endMonth: number | null }[],
+): Promise<void> {
+  const [existingExpOccs, savingsEntries, existingSavOccs] = await Promise.all([
+    prisma.expenseOccurrence.findMany({
+      where: { expenseId: { in: expenses.map((e) => e.id) }, year, month },
+      select: { expenseId: true },
+    }),
+    prisma.savingsEntry.findMany({
+      where: { budgetYearId },
+      select: { id: true, monthlyEquivalent: true },
+    }),
+    prisma.savingsOccurrence.findMany({
+      where: { savingsEntry: { budgetYearId }, year, month },
+      select: { savingsEntryId: true },
+    }),
+  ])
+
+  const existingExpIds = new Set(existingExpOccs.map((o) => o.expenseId))
+  const existingSavIds = new Set(existingSavOccs.map((o) => o.savingsEntryId))
+
+  const newExpOccs = expenses
+    .filter((e) => !existingExpIds.has(e.id))
+    .flatMap((e) => {
+      const scheduledAmount = calcOccurrenceScheduledAmount(e, month)
+      if (scheduledAmount === null) return []
+      return [{ expenseId: e.id, year, month, scheduledAmount, carriedAmount: new Decimal(0) }]
+    })
+
+  const newSavOccs = savingsEntries
+    .filter((s) => !existingSavIds.has(s.id))
+    .map((s) => ({
+      savingsEntryId: s.id,
+      year,
+      month,
+      scheduledAmount: new Decimal(s.monthlyEquivalent.toString()),
+      carriedAmount: new Decimal(0),
+    }))
+
+  await Promise.all([
+    newExpOccs.length > 0 ? prisma.expenseOccurrence.createMany({ data: newExpOccs }) : Promise.resolve(),
+    newSavOccs.length > 0 ? prisma.savingsOccurrence.createMany({ data: newSavOccs }) : Promise.resolve(),
+  ])
+}
+
+/**
+ * Called at month rollover for PAY_NO_PAY households.
+ * Closes all PENDING occurrences from the closing month (marks them SKIPPED),
+ * then opens occurrence rows for the new month — carrying over any unpaid balances.
+ */
+export async function rolloverPayNoPayOccurrences(
+  budgetYearId: string,
+  year: number,
+  closingMonth: number,
+  openingMonth: number,
+): Promise<void> {
+  // 1. Find PENDING occurrences from the closing month
+  const [pendingExpOccs, pendingSavOccs] = await Promise.all([
+    prisma.expenseOccurrence.findMany({
+      where: { expense: { budgetYearId }, year, month: closingMonth, status: 'PENDING' },
+    }),
+    prisma.savingsOccurrence.findMany({
+      where: { savingsEntry: { budgetYearId }, year, month: closingMonth, status: 'PENDING' },
+    }),
+  ])
+
+  // 2. Mark them SKIPPED
+  await Promise.all([
+    pendingExpOccs.length > 0
+      ? prisma.expenseOccurrence.updateMany({
+          where: { id: { in: pendingExpOccs.map((o) => o.id) } },
+          data: { status: 'SKIPPED' },
+        })
+      : Promise.resolve(),
+    pendingSavOccs.length > 0
+      ? prisma.savingsOccurrence.updateMany({
+          where: { id: { in: pendingSavOccs.map((o) => o.id) } },
+          data: { status: 'SKIPPED' },
+        })
+      : Promise.resolve(),
+  ])
+
+  // 3. Build carry-over maps: unpaid balance = scheduledAmount + carriedAmount - (actualAmount ?? 0)
+  const expenseCarryMap = new Map<string, Decimal>()
+  for (const occ of pendingExpOccs) {
+    const unpaid = new Decimal(occ.scheduledAmount.toString())
+      .add(new Decimal(occ.carriedAmount.toString()))
+      .sub(occ.actualAmount ? new Decimal(occ.actualAmount.toString()) : new Decimal(0))
+    if (unpaid.gt(0)) expenseCarryMap.set(occ.expenseId, unpaid)
+  }
+
+  const savingsCarryMap = new Map<string, Decimal>()
+  for (const occ of pendingSavOccs) {
+    const unpaid = new Decimal(occ.scheduledAmount.toString())
+      .add(new Decimal(occ.carriedAmount.toString()))
+      .sub(occ.actualAmount ? new Decimal(occ.actualAmount.toString()) : new Decimal(0))
+    if (unpaid.gt(0)) savingsCarryMap.set(occ.savingsEntryId, unpaid)
+  }
+
+  // 4. Fetch all expenses and savings entries for the budget year
+  const [expenses, savingsEntries] = await Promise.all([
+    prisma.expense.findMany({
+      where: { budgetYearId },
+      select: { id: true, monthlyEquivalent: true, startMonth: true, endMonth: true },
+    }),
+    prisma.savingsEntry.findMany({
+      where: { budgetYearId },
+      select: { id: true, monthlyEquivalent: true },
+    }),
+  ])
+
+  // 5. Upsert opening month occurrences (create fresh or merge carry into existing)
+  await Promise.all([
+    ...expenses.map(async (expense) => {
+      const scheduledAmount = calcOccurrenceScheduledAmount(expense, openingMonth)
+      const carriedAmount = expenseCarryMap.get(expense.id) ?? new Decimal(0)
+      if (scheduledAmount === null && carriedAmount.eq(0)) return
+      await prisma.expenseOccurrence.upsert({
+        where: { expenseId_year_month: { expenseId: expense.id, year, month: openingMonth } },
+        create: {
+          expenseId: expense.id,
+          year,
+          month: openingMonth,
+          scheduledAmount: scheduledAmount ?? new Decimal(0),
+          carriedAmount,
+        },
+        update: { carriedAmount },
+      })
+    }),
+    ...savingsEntries.map(async (entry) => {
+      const carriedAmount = savingsCarryMap.get(entry.id) ?? new Decimal(0)
+      await prisma.savingsOccurrence.upsert({
+        where: { savingsEntryId_year_month: { savingsEntryId: entry.id, year, month: openingMonth } },
+        create: {
+          savingsEntryId: entry.id,
+          year,
+          month: openingMonth,
+          scheduledAmount: new Decimal(entry.monthlyEquivalent.toString()),
+          carriedAmount,
+        },
+        update: { carriedAmount },
+      })
+    }),
+  ])
 }

--- a/apps/api/src/lib/calculations.ts
+++ b/apps/api/src/lib/calculations.ts
@@ -60,6 +60,24 @@ export function calcForwardMonthlyNeed(
   return remainingNeed.div(remainingMonths)
 }
 
+/**
+ * Returns the scheduled amount due for a single occurrence of an expense in a given month.
+ * Returns null if the expense is not active in that month (outside startMonth/endMonth).
+ * For partial-year expenses, reverses the annual-average to get the per-active-month amount.
+ */
+export function calcOccurrenceScheduledAmount(
+  expense: { monthlyEquivalent: Decimal; startMonth: number | null; endMonth: number | null },
+  month: number,
+): Decimal | null {
+  const start = expense.startMonth ?? 1
+  const end = expense.endMonth ?? 12
+  if (month < start || month > end) return null
+  const active = activeMonthCount(expense.startMonth, expense.endMonth)
+  if (active === 12) return new Decimal(expense.monthlyEquivalent.toString())
+  // monthlyEquivalent = perActiveMonth * active / 12 → invert to get perActiveMonth
+  return new Decimal(expense.monthlyEquivalent.toString()).mul(12).div(active)
+}
+
 export function deriveBudgetStatus(year: number): 'ACTIVE' | 'FUTURE' | 'RETIRED' {
   const current = new Date().getFullYear()
   if (year < current) return 'RETIRED'


### PR DESCRIPTION
…rence rollover

- AVERAGE: equal perMonth split for all 12 months; clears forwardMonthlyEquivalent
- FORWARD_LOOKING: existing behaviour preserved; also writes each expense's proportional forward share to forwardMonthlyEquivalent
- PAY_NO_PAY: seeds current-month ExpenseOccurrence/SavingsOccurrence rows on each recalc, then sums PENDING (scheduledAmount + carriedAmount) per month
- calcOccurrenceScheduledAmount helper in calculations.ts reverses the annual- average to return the per-active-month amount (null outside startMonth/endMonth)
- rolloverPayNoPayOccurrences: called by monthly automation — marks closing-month PENDING occurrences as SKIPPED, carries unpaid balances into the opening month