### PR TITLE
fix: address all 9 open security issues (#108–#116, #102)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types:
+          - patch

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,10 +17,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit --audit-level=high
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -44,6 +57,7 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: API — build and push
+        id: build-api
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -51,6 +65,20 @@ jobs:
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
+
+      - name: API — Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/budgeteer-api:latest
+          format: sarif
+          output: trivy-api.sarif
+          severity: HIGH,CRITICAL
+
+      - name: API — upload Trivy results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-api.sarif
+          category: trivy-api
 
       # ── Web image ────────────────────────────────────────────────────────────
 
@@ -74,3 +102,17 @@ jobs:
           push: true
           tags: ${{ steps.meta-web.outputs.tags }}
           labels: ${{ steps.meta-web.outputs.labels }}
+
+      - name: Web — Trivy scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.OWNER }}/budgeteer-web:latest
+          format: sarif
+          output: trivy-web.sarif
+          severity: HIGH,CRITICAL
+
+      - name: Web — upload Trivy results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-web.sarif
+          category: trivy-web

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
+    "@fastify/helmet": "^13.0.2",
     "@fastify/jwt": "^8.0.0",
     "@fastify/multipart": "^8.3.1",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^6.12.0",
     "@fastify/swagger": "^8.14.0",
     "@fastify/swagger-ui": "^3.1.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,8 @@
 import Fastify from 'fastify'
 import cors from '@fastify/cors'
 import jwt from '@fastify/jwt'
+import helmet from '@fastify/helmet'
+import rateLimit from '@fastify/rate-limit'
 import fastifyStatic from '@fastify/static'
 import fastifyMultipart from '@fastify/multipart'
 import fs from 'fs'
@@ -35,9 +37,16 @@ app.register(cors, {
   credentials: true,
 })
 
-app.register(jwt, {
-  secret: process.env.JWT_SECRET || 'dev-secret-change-in-production',
-})
+const jwtSecret = process.env.JWT_SECRET
+if (!jwtSecret) throw new Error('JWT_SECRET environment variable is required')
+
+app.register(jwt, { secret: jwtSecret })
+
+// Security headers
+app.register(helmet)
+
+// Rate limiting — global: 200 req / 15 min
+app.register(rateLimit, { max: 200, timeWindow: '15 minutes' })
 
 const UPLOAD_DIR = process.env.UPLOAD_DIR ?? './uploads'
 fs.mkdirSync(path.resolve(UPLOAD_DIR, 'avatars'), { recursive: true })

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -19,7 +19,7 @@ const LOCKOUT_MINUTES = 15
 
 export async function authRoutes(fastify: FastifyInstance) {
   // POST /auth/login
-  fastify.post('/auth/login', async (request, reply) => {
+  fastify.post('/auth/login', { config: { rateLimit: { max: 10, timeWindow: '15 minutes' } } }, async (request, reply) => {
     const result = LoginSchema.safeParse(request.body)
     if (!result.success) {
       return reply.status(400).send({ error: 'Invalid request body' })

--- a/apps/api/src/routes/budgetYears.ts
+++ b/apps/api/src/routes/budgetYears.ts
@@ -36,7 +36,12 @@ type SourceBudgetYear = Prisma.BudgetYearGetPayload<{
   include: { expenses: { include: { customSplits: true } }; savingsEntries: { include: { customSplits: true } } }
 }>
 
-async function copyBudgetYearContent(tx: Prisma.TransactionClient, source: SourceBudgetYear, targetId: string) {
+async function copyBudgetYearContent(
+  tx: Prisma.TransactionClient,
+  source: SourceBudgetYear,
+  targetId: string,
+  memberIds: Set<string>,
+) {
   for (const e of source.expenses) {
     const newExpense = await tx.expense.create({
       data: {
@@ -54,9 +59,10 @@ async function copyBudgetYearContent(tx: Prisma.TransactionClient, source: Sourc
         ownedByUserId: e.ownedByUserId,
       },
     })
-    if (e.customSplits.length > 0) {
+    const validExpenseSplits = e.customSplits.filter((s) => memberIds.has(s.userId))
+    if (validExpenseSplits.length > 0) {
       await tx.expenseCustomSplit.createMany({
-        data: e.customSplits.map((s) => ({ expenseId: newExpense.id, userId: s.userId, pct: s.pct })),
+        data: validExpenseSplits.map((s) => ({ expenseId: newExpense.id, userId: s.userId, pct: s.pct })),
       })
     }
   }
@@ -74,9 +80,10 @@ async function copyBudgetYearContent(tx: Prisma.TransactionClient, source: Sourc
         categoryId: s.categoryId,
       },
     })
-    if (s.customSplits.length > 0) {
+    const validSavingsSplits = s.customSplits.filter((sp) => memberIds.has(sp.userId))
+    if (validSavingsSplits.length > 0) {
       await tx.savingsCustomSplit.createMany({
-        data: s.customSplits.map((sp) => ({ savingsEntryId: newEntry.id, userId: sp.userId, pct: sp.pct })),
+        data: validSavingsSplits.map((sp) => ({ savingsEntryId: newEntry.id, userId: sp.userId, pct: sp.pct })),
       })
     }
   }
@@ -152,15 +159,19 @@ export async function budgetYearRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Provide either { year } or { simulationName }', details: result.error.flatten() })
     }
 
-    const source = await prisma.budgetYear.findFirst({
-      where: { id: yearId, householdId },
-      include: {
-        expenses: { include: { customSplits: true } },
-        savingsEntries: { include: { customSplits: true } },
-      },
-    })
+    const [source, householdMembers] = await Promise.all([
+      prisma.budgetYear.findFirst({
+        where: { id: yearId, householdId },
+        include: {
+          expenses: { include: { customSplits: true } },
+          savingsEntries: { include: { customSplits: true } },
+        },
+      }),
+      prisma.householdMember.findMany({ where: { householdId }, select: { userId: true } }),
+    ])
     if (!source) return reply.status(404).send({ error: 'Budget year not found' })
 
+    const memberIds = new Set(householdMembers.map((m) => m.userId))
     const data = result.data
 
     if ('year' in data) {
@@ -175,7 +186,7 @@ export async function budgetYearRoutes(fastify: FastifyInstance) {
         const created = await tx.budgetYear.create({
           data: { householdId, year: data.year, status: deriveBudgetStatus(data.year), copiedFromId: source.id },
         })
-        await copyBudgetYearContent(tx, source, created.id)
+        await copyBudgetYearContent(tx, source, created.id, memberIds)
         return tx.budgetYear.findUnique({
           where: { id: created.id },
           include: { _count: { select: { expenses: true, savingsEntries: true } } },
@@ -194,7 +205,7 @@ export async function budgetYearRoutes(fastify: FastifyInstance) {
             copiedFromId: source.id,
           },
         })
-        await copyBudgetYearContent(tx, source, created.id)
+        await copyBudgetYearContent(tx, source, created.id, memberIds)
         return tx.budgetYear.findUnique({
           where: { id: created.id },
           include: { _count: { select: { expenses: true, savingsEntries: true } } },

--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
 import { prisma } from '../lib/prisma'
 import { authenticate } from '../plugins/authenticate'
 import { calcIncomeForYear, getIncomeReferenceDate } from '../lib/incomeCalc'
@@ -132,7 +133,9 @@ export async function dashboardRoutes(fastify: FastifyInstance) {
   // Optional ?budgetYearId= to view any year (including retired) as read-only
   fastify.get('/households/:id/summary', { preHandler: authenticate }, async (request, reply) => {
     const { id: householdId } = request.params as { id: string }
-    const { budgetYearId: requestedYearId } = request.query as { budgetYearId?: string }
+    const queryResult = z.object({ budgetYearId: z.string().cuid().optional() }).safeParse(request.query)
+    if (!queryResult.success) return reply.status(400).send({ error: 'Invalid query parameters' })
+    const requestedYearId = queryResult.data.budgetYearId
     const { sub: userId, role } = request.user
 
     if (!await assertHouseholdAccess(householdId, userId, role, reply)) return

--- a/apps/api/src/routes/households.ts
+++ b/apps/api/src/routes/households.ts
@@ -24,7 +24,7 @@ const UpdateMemberSchema = z.object({
 })
 
 const memberInclude = {
-  user: { select: { id: true, name: true, email: true, isActive: true, isProxy: true } },
+  user: { select: { id: true, name: true, email: true, isActive: true } },
 } as const
 
 // Returns the membership record for userId in householdId, or null if not a member
@@ -40,7 +40,9 @@ export async function householdRoutes(fastify: FastifyInstance) {
   fastify.get('/households', { preHandler: authenticate }, async (request, reply) => {
     const { sub: userId, role } = request.user
 
-    const includeInactive = role === 'SYSTEM_ADMIN' && (request.query as Record<string, string>).all === 'true'
+    const queryResult = z.object({ all: z.enum(['true', 'false']).optional() }).safeParse(request.query)
+    if (!queryResult.success) return reply.status(400).send({ error: 'Invalid query parameters' })
+    const includeInactive = role === 'SYSTEM_ADMIN' && queryResult.data.all === 'true'
     const activeFilter = includeInactive ? {} : { isActive: true }
     const where = role === 'SYSTEM_ADMIN'
       ? { ...activeFilter }

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -53,7 +53,7 @@ const UpdateBonusSchema = CreateBonusSchema.partial().refine(
 )
 
 const AllocationSchema = z.object({
-  allocationPct: z.number().min(0).max(999),
+  allocationPct: z.number().min(0).max(100),
 })
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -318,14 +318,17 @@ export async function jobRoutes(fastify: FastifyInstance) {
   // GET /jobs/:id/overrides
   fastify.get('/jobs/:id/overrides', { preHandler: authenticate }, async (request, reply) => {
     const { id: jobId } = request.params as { id: string }
-    const { year } = request.query as { year?: string }
     const { sub: userId, role } = request.user
+
+    const queryResult = z.object({ year: z.coerce.number().int().min(2000).max(2100).optional() }).safeParse(request.query)
+    if (!queryResult.success) return reply.status(400).send({ error: 'Invalid query parameters' })
+    const { year } = queryResult.data
 
     const job = await assertJobOwnership(jobId, userId, role)
     if (!job) return reply.status(404).send({ error: 'Job not found' })
 
     const overrides = await prisma.monthlyIncomeOverride.findMany({
-      where: { jobId, ...(year ? { year: parseInt(year, 10) } : {}) },
+      where: { jobId, ...(year !== undefined ? { year } : {}) },
       orderBy: [{ year: 'desc' }, { month: 'desc' }],
     })
 
@@ -539,11 +542,13 @@ export async function jobRoutes(fastify: FastifyInstance) {
   // GET /users/:id/income/history?from=YYYY-MM&to=YYYY-MM&granularity=monthly|quarterly|yearly
   fastify.get('/users/:id/income/history', { preHandler: authenticate }, async (request, reply) => {
     const { id: targetUserId } = request.params as { id: string }
-    const { from, to, granularity = 'monthly' } = request.query as {
-      from?: string
-      to?: string
-      granularity?: 'monthly' | 'quarterly' | 'yearly'
-    }
+    const queryResult = z.object({
+      granularity: z.enum(['monthly', 'quarterly', 'yearly']).default('monthly'),
+      from: z.string().regex(/^\d{4}-\d{2}$/).optional(),
+      to: z.string().regex(/^\d{4}-\d{2}$/).optional(),
+    }).safeParse(request.query)
+    if (!queryResult.success) return reply.status(400).send({ error: 'Invalid query parameters' })
+    const { from, to, granularity } = queryResult.data
     const { sub: userId, role } = request.user
 
     if (role !== 'SYSTEM_ADMIN' && userId !== targetUserId) {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -61,11 +61,22 @@ const userSelect = {
 } as const
 
 export async function userRoutes(fastify: FastifyInstance) {
-  // GET /users — all authenticated users can list; needed so household admins can pick members
-  fastify.get('/users', { preHandler: authenticate }, async (_request, reply) => {
+  // GET /users — scoped by role:
+  //   SYSTEM_ADMIN / BOOKKEEPER → full user list (needed for admin management)
+  //   Regular user / household admin → minimal list of active non-admin users (for member-invite picker)
+  fastify.get('/users', { preHandler: authenticate }, async (request, reply) => {
+    const { role } = request.user
+    if (role === 'SYSTEM_ADMIN' || role === 'BOOKKEEPER') {
+      const users = await prisma.user.findMany({
+        select: userSelect,
+        orderBy: { createdAt: 'asc' },
+      })
+      return reply.send(users)
+    }
     const users = await prisma.user.findMany({
-      select: userSelect,
-      orderBy: { createdAt: 'asc' },
+      where: { isActive: true, role: 'USER', isProxy: false },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
     })
     return reply.send(users)
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,10 @@
       "version": "0.14.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
+        "@fastify/helmet": "^13.0.2",
         "@fastify/jwt": "^8.0.0",
         "@fastify/multipart": "^8.3.1",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^6.12.0",
         "@fastify/swagger": "^8.14.0",
         "@fastify/swagger-ui": "^3.1.0",
@@ -1059,6 +1061,42 @@
         "fast-json-stringify": "^5.7.0"
       }
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
+    "node_modules/@fastify/helmet/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/jwt": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/jwt/-/jwt-8.0.1.tgz",
@@ -1080,6 +1118,43 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/@fastify/rate-limit": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-10.3.0.tgz",
+      "integrity": "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/rate-limit/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/send": {
       "version": "2.1.0",
@@ -4397,6 +4472,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hono": {


### PR DESCRIPTION
- #108 (Critical): Fail fast on startup if JWT_SECRET is not set; remove hardcoded fallback
- #109 (High): Register @fastify/rate-limit globally (200/15 min) with tighter limit on /auth/login (10/15 min)
- #112 (Low): Register @fastify/helmet for HTTP security headers
- #110 (High): Scope GET /users by role — regular users receive only {id,name} of active non-admin peers
- #113 (Medium): Cap allocationPct at 100 (was 999) in AllocationSchema
- #116 (Medium): Filter custom splits by current household membership when copying budget years
- #115 (Low): Remove isProxy from memberInclude select to prevent internal architecture disclosure
- #114 (Low): Validate query params with Zod in jobs, households, and dashboard routes
- #102 (DevOps): Add dependabot.yml, CodeQL workflow, and Trivy image scanning + npm audit to CI

https://claude.ai/code/session_01Lq43abFVnyHZNhEFmoiGR1