### PR TITLE
fix(ui): mobile & responsive design fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.49.0] - 2026-04-11 — Mobile & responsive design fixes
+
+### Added
+- **Household name as dashboard link** — the household name in the top header is now a clickable link back to the household dashboard, making it easy to return to the overview from any page on small screens; multi-household users retain the chevron dropdown for switching
+
+### Fixed
+- **Table horizontal scrolling** — all data tables (expenses, savings, income, dashboard, household settings, categories, budget years, compare, and all admin pages) now scroll horizontally on narrow screens instead of being clipped/invisible inside their `overflow-hidden` card containers; minimum widths set per table based on column count
+- **Sidebar visible on foldable and landscape phones** — the persistent sidebar now appears at ≥ 640 px (was ≥ 768 px), so foldable phones (~673 px wide) and phones in landscape mode (~667 px wide) get the static sidebar layout
+- **Admin navigation overflow** — the admin panel header navigation no longer clips on narrow screens; the header scrolls horizontally when its content exceeds the viewport width
+- **Modal padding on small screens** — modal dialogs use reduced inner padding (`p-4`) on phones, giving form content adequate room; padding restores to `p-6` at ≥ 640 px
+
+---
+
 ## [0.48.0] - 2026-04-06 — Security: Fastify v5 migration (Sprint 24)
 
 ### Security

--- a/apps/web/src/components/HouseholdSwitcher.tsx
+++ b/apps/web/src/components/HouseholdSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState } from 'react'
 import { ChevronDown, Pin, PinOff, Plus } from 'lucide-react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 import { useHousehold } from '../contexts/HouseholdContext'
@@ -61,18 +61,31 @@ export default function HouseholdSwitcher({ currentHouseholdId }: Props) {
   const defaultId = preferences?.defaultHouseholdId
 
   if (households.length <= 1) {
-    return <span className="text-gray-300 text-sm">{current?.name ?? '…'}</span>
+    return (
+      <Link to={`/households/${currentHouseholdId}`} className="text-gray-300 text-sm hover:text-white transition-colors">
+        {current?.name ?? '…'}
+      </Link>
+    )
   }
 
   return (
     <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1.5 text-gray-300 text-sm hover:text-white transition-colors"
-      >
-        {current?.name ?? '…'}
-        <ChevronDown size={14} className="text-gray-500" />
-      </button>
+      <div className="flex items-center gap-0.5">
+        <Link
+          to={`/households/${currentHouseholdId}`}
+          className="text-gray-300 text-sm hover:text-white transition-colors"
+          onClick={() => setOpen(false)}
+        >
+          {current?.name ?? '…'}
+        </Link>
+        <button
+          onClick={() => setOpen((o) => !o)}
+          className="text-gray-500 hover:text-white transition-colors p-0.5"
+          aria-label="Switch household"
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
 
       {open && (
         <div className="absolute left-0 mt-2 w-64 bg-gray-900 border border-gray-800 rounded-xl shadow-lg z-50 overflow-hidden">

--- a/apps/web/src/components/Modal.tsx
+++ b/apps/web/src/components/Modal.tsx
@@ -31,7 +31,7 @@ export function Modal({ title, onClose, children, size = 'md' }: ModalProps) {
       className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div ref={dialogRef} className={`bg-gray-900 border border-gray-800 rounded-xl w-full ${sizeClass[size]} p-6`}>
+      <div ref={dialogRef} className={`bg-gray-900 border border-gray-800 rounded-xl w-full ${sizeClass[size]} p-4 sm:p-6`}>
         <div className="flex items-center justify-between mb-5">
           <h2 className="text-lg font-semibold">{title}</h2>
           <button onClick={onClose} className="text-gray-500 hover:text-white transition-colors" aria-label="Close">

--- a/apps/web/src/layouts/AdminLayout.tsx
+++ b/apps/web/src/layouts/AdminLayout.tsx
@@ -15,8 +15,8 @@ export function AdminLayout() {
 
   return (
     <div className="min-h-screen bg-gray-950 text-white flex flex-col">
-      <header className="bg-gray-900 border-b border-gray-800 px-6 py-4 flex items-center justify-between flex-shrink-0">
-        <div className="flex items-center gap-4">
+      <header className="bg-gray-900 border-b border-gray-800 px-6 py-4 flex items-center justify-between flex-shrink-0 overflow-x-auto">
+        <div className="flex items-center gap-4 min-w-max">
           <Link to="/" className="text-amber-400 font-bold text-lg hover:text-amber-300 transition-colors">
             ☠️ Budgeteer
           </Link>

--- a/apps/web/src/layouts/HouseholdLayout.tsx
+++ b/apps/web/src/layouts/HouseholdLayout.tsx
@@ -100,7 +100,7 @@ export function HouseholdLayout() {
           {/* Hamburger — mobile only */}
           <button
             onClick={() => setSidebarOpen(true)}
-            className="md:hidden text-gray-400 hover:text-white transition-colors mr-1"
+            className="sm:hidden text-gray-400 hover:text-white transition-colors mr-1"
             aria-label="Open menu"
           >
             <Menu size={20} />
@@ -122,7 +122,7 @@ export function HouseholdLayout() {
         {/* Mobile overlay */}
         {sidebarOpen && (
           <div
-            className="fixed inset-0 bg-black/60 z-40 md:hidden"
+            className="fixed inset-0 bg-black/60 z-40 sm:hidden"
             onClick={() => setSidebarOpen(false)}
           />
         )}
@@ -131,11 +131,11 @@ export function HouseholdLayout() {
         <nav className={`
           fixed inset-y-0 left-0 z-50 w-56 bg-gray-900 border-r border-gray-800 flex flex-col py-4
           transform transition-transform duration-200
-          md:static md:translate-x-0 md:z-auto md:flex-shrink-0 md:overflow-y-auto
+          sm:static sm:translate-x-0 sm:z-auto sm:flex-shrink-0 sm:overflow-y-auto
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
         `}>
           {/* Close button — mobile only */}
-          <div className="flex items-center justify-between px-4 pb-3 mb-1 border-b border-gray-800 md:hidden">
+          <div className="flex items-center justify-between px-4 pb-3 mb-1 border-b border-gray-800 sm:hidden">
             <span className="text-sm font-medium text-gray-300">Menu</span>
             <button onClick={() => setSidebarOpen(false)} className="text-gray-400 hover:text-white transition-colors">
               <X size={18} />

--- a/apps/web/src/pages/BudgetYearsPage.tsx
+++ b/apps/web/src/pages/BudgetYearsPage.tsx
@@ -257,7 +257,8 @@ export function BudgetYearsPage() {
                 </div>
               ) : (
                 <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-                  <table className="w-full text-sm">
+                  <div className="overflow-x-auto">
+                  <table className="w-full text-sm min-w-[520px]">
                     <thead>
                       <tr className="border-b border-gray-800 text-gray-400 text-left">
                         <th className="px-4 py-3 font-medium">Year</th>
@@ -308,6 +309,7 @@ export function BudgetYearsPage() {
                       ))}
                     </tbody>
                   </table>
+                  </div>
                 </div>
               )}
             </section>
@@ -323,7 +325,8 @@ export function BudgetYearsPage() {
                 </div>
               ) : (
                 <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-                  <table className="w-full text-sm">
+                  <div className="overflow-x-auto">
+                  <table className="w-full text-sm min-w-[520px]">
                     <thead>
                       <tr className="border-b border-gray-800 text-gray-400 text-left">
                         <th className="px-4 py-3 font-medium">Name</th>
@@ -376,6 +379,7 @@ export function BudgetYearsPage() {
                       ))}
                     </tbody>
                   </table>
+                  </div>
                 </div>
               )}
             </section>

--- a/apps/web/src/pages/CategoriesPage.tsx
+++ b/apps/web/src/pages/CategoriesPage.tsx
@@ -175,7 +175,8 @@ export function CategoriesPage() {
             <p className="text-gray-500 text-sm">Uncharted territory — no custom expense categories yet.</p>
           ) : (
             <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[480px]">
                 <thead>
                   <tr className="border-b border-gray-800 text-gray-400 text-left">
                     <th className="px-4 py-3 font-medium">Name</th>
@@ -220,6 +221,7 @@ export function CategoriesPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
         </div>
@@ -244,7 +246,8 @@ export function CategoriesPage() {
             <p className="text-gray-500 text-sm">No custom savings categories yet.</p>
           ) : (
             <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[480px]">
                 <thead>
                   <tr className="border-b border-gray-800 text-gray-400 text-left">
                     <th className="px-4 py-3 font-medium">Name</th>
@@ -289,6 +292,7 @@ export function CategoriesPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
         </div>
@@ -297,7 +301,8 @@ export function CategoriesPage() {
         <div>
           <h2 className="text-lg font-semibold mb-4">System categories</h2>
           <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-            <table className="w-full text-sm">
+            <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[480px]">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
                   <th className="px-4 py-3 font-medium">Name</th>
@@ -341,6 +346,7 @@ export function CategoriesPage() {
                 ))}
               </tbody>
             </table>
+            </div>
           </div>
         </div>
       </main>

--- a/apps/web/src/pages/ComparePage.tsx
+++ b/apps/web/src/pages/ComparePage.tsx
@@ -331,7 +331,8 @@ export function ComparePage() {
 
           {/* COMP-002: Side-by-side expense table */}
           <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
+            <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[640px]">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
                   <th className="px-4 py-3 font-medium">Expense</th>
@@ -419,6 +420,7 @@ export function ComparePage() {
                 </tfoot>
               )}
             </table>
+            </div>
           </div>
         </>
       ) : null}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -469,6 +469,7 @@ export function DashboardPage() {
               </div>
             ) : (
               <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+                <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-gray-800 text-gray-400 text-left">
@@ -515,6 +516,7 @@ export function DashboardPage() {
                     </tr>
                   </tfoot>
                 </table>
+                </div>
               </div>
             )}
           </div>
@@ -624,7 +626,8 @@ export function DashboardPage() {
                 </p>
               ) : (
                 <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-                  <table className="w-full text-sm">
+                  <div className="overflow-x-auto">
+                  <table className="w-full text-sm min-w-[520px]">
                     <thead>
                       <tr className="border-b border-gray-800 text-gray-400 text-left">
                         <th className="px-4 py-3 font-medium">Month</th>
@@ -680,6 +683,7 @@ export function DashboardPage() {
                       ))}
                     </tbody>
                   </table>
+                  </div>
                 </div>
               )
             )}
@@ -690,6 +694,7 @@ export function DashboardPage() {
             <div className="mb-8">
               <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wide mb-3">Transfer by account</h2>
               <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+                <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <tbody>
                     {transferBreakdown.byAccount.map((a) => (
@@ -707,6 +712,7 @@ export function DashboardPage() {
                     ))}
                   </tbody>
                 </table>
+                </div>
               </div>
             </div>
           )}

--- a/apps/web/src/pages/ExpensesPage.tsx
+++ b/apps/web/src/pages/ExpensesPage.tsx
@@ -613,7 +613,8 @@ export function ExpensesPage() {
               <ExpenseCalendar expenses={filtered} fmt={fmt} />
             ) : (
               <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full text-sm min-w-[700px]">
                   <thead>
                     <tr className="border-b border-gray-800 text-gray-400 text-left select-none">
                       <th className="pl-4 pr-2 py-3 w-8">
@@ -752,6 +753,7 @@ export function ExpensesPage() {
                     </tr>
                   </tfoot>
                 </table>
+                </div>
               </div>
             )}
           </>

--- a/apps/web/src/pages/HouseholdPage.tsx
+++ b/apps/web/src/pages/HouseholdPage.tsx
@@ -351,7 +351,8 @@ export function HouseholdPage() {
         </div>
 
         <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full text-sm min-w-[480px]">
             <thead>
               <tr className="border-b border-gray-800 text-gray-400 text-left">
                 <th className="px-4 py-3 font-medium">Name</th>
@@ -423,6 +424,7 @@ export function HouseholdPage() {
               })}
             </tbody>
           </table>
+          </div>
         </div>
 
         {/* Household accounts */}
@@ -443,7 +445,8 @@ export function HouseholdPage() {
             <p className="text-sm text-gray-500">No household accounts yet.</p>
           ) : (
             <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[480px]">
                 <thead>
                   <tr className="border-b border-gray-800 text-gray-400 text-left">
                     <th className="px-4 py-3 font-medium">Name</th>
@@ -496,6 +499,7 @@ export function HouseholdPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
         </div>

--- a/apps/web/src/pages/IncomePage.tsx
+++ b/apps/web/src/pages/IncomePage.tsx
@@ -652,7 +652,8 @@ export function IncomePage() {
                         {overrides.length === 0 ? (
                           <p className="text-gray-600 text-sm">No overrides for this job.</p>
                         ) : (
-                          <table className="w-full text-sm">
+                          <div className="overflow-x-auto">
+                          <table className="w-full text-sm min-w-[480px]">
                             <thead>
                               <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-800">
                                 <th className="pb-2 pr-4">Month</th>
@@ -677,6 +678,7 @@ export function IncomePage() {
                               ))}
                             </tbody>
                           </table>
+                          </div>
                         )}
                       </div>
                     )
@@ -716,7 +718,8 @@ export function IncomePage() {
                         {bonuses.length === 0 ? (
                           <p className="text-gray-600 text-sm">No bonuses for this job.</p>
                         ) : (
-                          <table className="w-full text-sm">
+                          <div className="overflow-x-auto">
+                          <table className="w-full text-sm min-w-[560px]">
                             <thead>
                               <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-800">
                                 <th className="pb-2 pr-4">Label</th>
@@ -754,6 +757,7 @@ export function IncomePage() {
                               ))}
                             </tbody>
                           </table>
+                          </div>
                         )}
                       </div>
                     )
@@ -809,7 +813,8 @@ export function IncomePage() {
         <Modal title={`Salary history — ${jobs.find((j) => j.id === salaryJobId)?.name}`} onClose={() => { setSalaryJobId(null); setEditingSalary(null); setSalaryForm(emptySalary(baseCurrency)); setSalaryError('') }} size="lg">
           {/* Existing records */}
           {salaryRecords.length > 0 && (
-            <table className="w-full text-sm mb-6">
+            <div className="overflow-x-auto mb-6">
+            <table className="w-full text-sm min-w-[480px]">
               <thead>
                 <tr className="text-left text-xs text-gray-500 uppercase tracking-wide border-b border-gray-800">
                   <th className="pb-2 pr-4">Effective from</th>
@@ -841,6 +846,7 @@ export function IncomePage() {
                 ))}
               </tbody>
             </table>
+            </div>
           )}
 
           {/* Add / Edit record */}

--- a/apps/web/src/pages/SavingsPage.tsx
+++ b/apps/web/src/pages/SavingsPage.tsx
@@ -515,7 +515,8 @@ export function SavingsPage() {
             </div>
           )}
           <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-            <table className="w-full text-sm">
+            <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[640px]">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
                   {!isReadOnly && (
@@ -617,6 +618,7 @@ export function SavingsPage() {
                 </tr>
               </tfoot>
             </table>
+            </div>
           </div>
           </>
         )}

--- a/apps/web/src/pages/admin/AutomationsAdminPage.tsx
+++ b/apps/web/src/pages/admin/AutomationsAdminPage.tsx
@@ -136,7 +136,8 @@ export function AutomationsAdminPage() {
         <p className="text-gray-600 text-sm">No automations registered.</p>
       ) : (
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full text-sm min-w-[640px]">
             <thead>
               <tr className="border-b border-gray-800 text-gray-400 text-left">
                 <th className="px-4 py-3 font-medium">Household</th>
@@ -196,6 +197,7 @@ export function AutomationsAdminPage() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/apps/web/src/pages/admin/CategoriesAdminPage.tsx
+++ b/apps/web/src/pages/admin/CategoriesAdminPage.tsx
@@ -234,7 +234,8 @@ function SystemCategoryTable({
 
   return (
     <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-      <table className="w-full text-sm">
+      <div className="overflow-x-auto">
+      <table className="w-full text-sm min-w-[560px]">
         <thead>
           <tr className="border-b border-gray-800 text-gray-400 text-left">
             <th className="px-4 py-3 font-medium">Name</th>
@@ -294,6 +295,7 @@ function SystemCategoryTable({
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   )
 }
@@ -317,7 +319,8 @@ function CustomCategoryTable({
         Promote a household category to make it available to all households as a system-wide category.
       </p>
       <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-        <table className="w-full text-sm">
+        <div className="overflow-x-auto">
+        <table className="w-full text-sm min-w-[560px]">
           <thead>
             <tr className="border-b border-gray-800 text-gray-400 text-left">
               <th className="px-4 py-3 font-medium">Name</th>
@@ -355,6 +358,7 @@ function CustomCategoryTable({
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     </>
   )

--- a/apps/web/src/pages/admin/CurrenciesAdminPage.tsx
+++ b/apps/web/src/pages/admin/CurrenciesAdminPage.tsx
@@ -140,7 +140,8 @@ export function CurrenciesAdminPage() {
         <div className="text-center py-20 text-gray-500">No currencies yet — add one to get started.</div>
       ) : (
         <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-          <table className="w-full text-sm">
+          <div className="overflow-x-auto">
+          <table className="w-full text-sm min-w-[640px]">
             <thead>
               <tr className="border-b border-gray-800 text-gray-400 text-left">
                 <th className="px-4 py-3 font-medium">Code</th>
@@ -202,6 +203,7 @@ export function CurrenciesAdminPage() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/apps/web/src/pages/admin/HouseholdsAdminPage.tsx
+++ b/apps/web/src/pages/admin/HouseholdsAdminPage.tsx
@@ -56,7 +56,8 @@ export function HouseholdsAdminPage() {
           <div className="text-center py-20 text-gray-500">No crews on the seas yet.</div>
         ) : (
           <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-            <table className="w-full text-sm">
+            <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[560px]">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
                   <th className="px-4 py-3 font-medium">Name</th>
@@ -102,6 +103,7 @@ export function HouseholdsAdminPage() {
                 })}
               </tbody>
             </table>
+            </div>
           </div>
         )}
       </main>

--- a/apps/web/src/pages/admin/UsersPage.tsx
+++ b/apps/web/src/pages/admin/UsersPage.tsx
@@ -180,7 +180,8 @@ export function AdminUsersPage() {
           <PageLoader />
         ) : (
           <div className="bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
-            <table className="w-full text-sm">
+            <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[560px]">
               <thead>
                 <tr className="border-b border-gray-800 text-gray-400 text-left">
                   <th className="px-4 py-3 font-medium">Name</th>
@@ -228,6 +229,7 @@ export function AdminUsersPage() {
                 ))}
               </tbody>
             </table>
+            </div>
           </div>
         )}
       </main>


### PR DESCRIPTION
## Summary

- **Table scrolling** — all 22 data tables across 13 files now scroll horizontally on narrow screens instead of being silently clipped inside `overflow-hidden` card containers; `min-w-[Npx]` set per table based on column count
- **Sidebar breakpoint** — lowered `md:` → `sm:` in `HouseholdLayout`; foldable phones (~673 px) and landscape phones (~667 px) now get the persistent static sidebar instead of the mobile drawer
- **Admin nav overflow** — admin header scrolls horizontally on narrow screens rather than clipping nav links
- **Modal padding** — reduced to `p-4` on small screens, restores to `p-6` at ≥ 640 px
- **Household name → dashboard link** — the household name in the top header is now a link back to the household dashboard; multi-household users retain the chevron dropdown as a separate trigger

## Test plan

- [ ] **360 × 800 portrait** — mobile drawer nav, all tables scroll horizontally
- [ ] **667 × 375 landscape** (iPhone SE) — static sidebar visible, tables scroll
- [ ] **673 × 841** (Galaxy Z Fold open) — static sidebar visible
- [ ] **768 × 1024** (iPad) — static sidebar unchanged
- [ ] **1280 × 800** desktop — no visual regressions
- [ ] Expenses/Savings pages: table scrolls, Edit/Delete buttons visible
- [ ] Dashboard: transfers table scrolls on narrow screens
- [ ] Admin panel: header nav scrolls rather than clips on small screens
- [ ] New Expense / New Savings modal: form fields have adequate width at 360 px
- [ ] Household name in header navigates to dashboard; chevron still opens switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)