### PR TITLE
feat(income): payslip deduction breakdown — data foundation (Sprint 25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.50.0] - 2026-04-11 — Payslip income breakdown: data foundation (Sprint 25)
+
+### Added
+- **`Job.country` field** — each job now carries a country code (default `"DK"`); drives country-specific payslip UI and tax calculation in later sprints
+- **`TaxCardSettings` model** — per-job, effective-dated tax card configuration for Danish payroll: trækprocent, personfradrag (monthly), municipality label, employee/employer pension percentages, ATP override, and a `bruttoItems` JSON list for pre-tax salary-sacrifice deductions (bruttolønsordning)
+- **Payslip deduction breakdown on `SalaryRecord`** — optional fields `amBidragAmount`, `aSkattAmount`, `pensionEmployeeAmount`, `pensionEmployerAmount`, `atpAmount`, `bruttoDeductionAmount`, `otherDeductions` (JSON), and `deductionsSource` (`"MANUAL"` | `"CALCULATED"`); Zod validates net ≈ gross − deductions (±1 DKK tolerance) when deductions are provided
+- **Same deduction fields on `MonthlyIncomeOverride`** — mirrors the salary-record breakdown so per-month payslip data can be recorded for unusual months (overtime, tax changes, etc.)
+- **Tax card settings API** — `GET/POST/PUT/DELETE /jobs/:id/taxcard` for managing `TaxCardSettings` records; follows same effective-date versioning pattern as salary records
+- **Shared payslip types** — `BruttoItem`, `OtherDeductionItem`, `DeductionFields`, and `TaxCardSettingsData` interfaces exported from `packages/shared`
+
+---
+
 ## [0.49.0] - 2026-04-11 — Mobile & responsive design fixes
 
 ### Added

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -13,6 +13,7 @@ import { toNum } from '../lib/decimal'
 const CreateJobSchema = z.object({
   name: z.string().min(1).max(200),
   employer: z.string().max(200).optional(),
+  country: z.string().min(2).max(10).toUpperCase().default('DK'),
   startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 })
@@ -22,20 +23,94 @@ const UpdateJobSchema = CreateJobSchema.partial().refine(
   { message: 'At least one field is required' }
 )
 
-const CreateSalarySchema = z.object({
-  grossAmount: z.number().positive(),
-  netAmount: z.number().positive(),
-  effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  currencyCode: z.string().length(3).toUpperCase().optional(),
+const OtherDeductionItemSchema = z.object({
+  label: z.string().min(1).max(100),
+  amount: z.number().nonnegative(),
 })
 
-const OverrideSchema = z.object({
-  year: z.number().int().min(2000).max(2100),
-  month: z.number().int().min(1).max(12),
-  grossAmount: z.number().positive(),
-  netAmount: z.number().positive(),
-  note: z.string().max(500).optional(),
+const DeductionFieldsSchema = z.object({
+  amBidragAmount: z.number().nonnegative().optional(),
+  aSkattAmount: z.number().nonnegative().optional(),
+  pensionEmployeeAmount: z.number().nonnegative().optional(),
+  pensionEmployerAmount: z.number().nonnegative().optional(),
+  atpAmount: z.number().nonnegative().optional(),
+  bruttoDeductionAmount: z.number().nonnegative().optional(),
+  otherDeductions: z.array(OtherDeductionItemSchema).optional(),
+  deductionsSource: z.enum(['MANUAL', 'CALCULATED']).optional(),
 })
+
+function validateDeductionNet(
+  grossAmount: number,
+  netAmount: number,
+  d: z.infer<typeof DeductionFieldsSchema>,
+  ctx: z.RefinementCtx
+) {
+  const hasDeductions =
+    d.amBidragAmount !== undefined ||
+    d.aSkattAmount !== undefined ||
+    d.bruttoDeductionAmount !== undefined
+  if (!hasDeductions) return
+  const brutto = d.bruttoDeductionAmount ?? 0
+  const amBidrag = d.amBidragAmount ?? 0
+  const aSkat = d.aSkattAmount ?? 0
+  const pensionEmp = d.pensionEmployeeAmount ?? 0
+  const atp = d.atpAmount ?? 0
+  const other = (d.otherDeductions ?? []).reduce((s, i) => s + i.amount, 0)
+  const expectedNet = grossAmount - brutto - amBidrag - aSkat - pensionEmp - atp - other
+  if (Math.abs(expectedNet - netAmount) > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `netAmount (${netAmount}) does not match gross minus deductions (expected ~${expectedNet.toFixed(2)}, tolerance ±1)`,
+      path: ['netAmount'],
+    })
+  }
+}
+
+const CreateSalarySchema = z
+  .object({
+    grossAmount: z.number().positive(),
+    netAmount: z.number().positive(),
+    effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    currencyCode: z.string().length(3).toUpperCase().optional(),
+  })
+  .merge(DeductionFieldsSchema)
+  .superRefine((data, ctx) => {
+    validateDeductionNet(data.grossAmount, data.netAmount, data, ctx)
+  })
+
+const OverrideSchema = z
+  .object({
+    year: z.number().int().min(2000).max(2100),
+    month: z.number().int().min(1).max(12),
+    grossAmount: z.number().positive(),
+    netAmount: z.number().positive(),
+    note: z.string().max(500).optional(),
+  })
+  .merge(DeductionFieldsSchema)
+  .superRefine((data, ctx) => {
+    validateDeductionNet(data.grossAmount, data.netAmount, data, ctx)
+  })
+
+const BruttoItemSchema = z.object({
+  label: z.string().min(1).max(100),
+  monthlyAmount: z.number().nonnegative(),
+})
+
+const CreateTaxCardSchema = z.object({
+  effectiveFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  traekprocent: z.number().min(0).max(100),
+  personfradragMonthly: z.number().nonnegative(),
+  municipality: z.string().max(100).optional(),
+  pensionEmployeePct: z.number().min(0).max(100).optional(),
+  pensionEmployerPct: z.number().min(0).max(100).optional(),
+  atpAmount: z.number().nonnegative().optional(),
+  bruttoItems: z.array(BruttoItemSchema).optional(),
+})
+
+const UpdateTaxCardSchema = CreateTaxCardSchema.partial().refine(
+  (d) => Object.keys(d).length > 0,
+  { message: 'At least one field is required' }
+)
 
 const CreateBonusSchema = z.object({
   label: z.string().min(1).max(200),
@@ -117,6 +192,7 @@ export async function jobRoutes(fastify: FastifyInstance) {
       id: j.id,
       name: j.name,
       employer: j.employer,
+      country: j.country,
       startDate: j.startDate,
       endDate: j.endDate,
       isActive: j.endDate === null || j.endDate > new Date(),
@@ -151,12 +227,13 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { name, employer, startDate, endDate } = result.data
+    const { name, employer, country, startDate, endDate } = result.data
     const job = await prisma.job.create({
       data: {
         userId: targetUserId,
         name,
         employer,
+        country,
         startDate: new Date(startDate),
         endDate: endDate ? new Date(endDate) : null,
       },
@@ -178,12 +255,13 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { name, employer, startDate, endDate } = result.data
+    const { name, employer, country, startDate, endDate } = result.data
     const updated = await prisma.job.update({
       where: { id: jobId },
       data: {
         ...(name !== undefined && { name }),
         ...(employer !== undefined && { employer }),
+        ...(country !== undefined && { country }),
         ...(startDate !== undefined && { startDate: new Date(startDate) }),
         ...(endDate !== undefined && { endDate: new Date(endDate) }),
       },
@@ -239,7 +317,11 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { grossAmount, netAmount, effectiveFrom, currencyCode } = result.data
+    const {
+      grossAmount, netAmount, effectiveFrom, currencyCode,
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    } = result.data
     const currency = currencyCode && currencyCode !== BASE_CURRENCY ? currencyCode : null
     const rate = currency ? await getLatestRate(currency) : null
     if (currency && rate === null) {
@@ -254,6 +336,14 @@ export async function jobRoutes(fastify: FastifyInstance) {
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
+        amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
+        aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
+        pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
+        pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
+        atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
+        bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
+        otherDeductions: otherDeductions ?? undefined,
+        deductionsSource: deductionsSource ?? null,
       },
     })
 
@@ -276,7 +366,11 @@ export async function jobRoutes(fastify: FastifyInstance) {
     const existing = await prisma.salaryRecord.findFirst({ where: { id: salaryId, jobId } })
     if (!existing) return reply.status(404).send({ error: 'Salary record not found' })
 
-    const { grossAmount, netAmount, effectiveFrom, currencyCode } = result.data
+    const {
+      grossAmount, netAmount, effectiveFrom, currencyCode,
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    } = result.data
     const currency = currencyCode && currencyCode !== BASE_CURRENCY ? currencyCode : null
     const rate = currency ? await getLatestRate(currency) : null
     if (currency && rate === null) {
@@ -291,6 +385,14 @@ export async function jobRoutes(fastify: FastifyInstance) {
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
+        amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
+        aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
+        pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
+        pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
+        atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
+        bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
+        otherDeductions: otherDeductions ?? undefined,
+        deductionsSource: deductionsSource ?? null,
       },
     })
 
@@ -348,11 +450,27 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const { year, month, grossAmount, netAmount, note } = result.data
+    const {
+      year, month, grossAmount, netAmount, note,
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    } = result.data
+
+    const deductionData = {
+      amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
+      aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
+      pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
+      pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
+      atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
+      bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
+      otherDeductions: otherDeductions ?? undefined,
+      deductionsSource: deductionsSource ?? null,
+    }
+
     const override = await prisma.monthlyIncomeOverride.upsert({
       where: { jobId_year_month: { jobId, year, month } },
-      create: { jobId, year, month, grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note },
-      update: { grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note },
+      create: { jobId, year, month, grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note, ...deductionData },
+      update: { grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note, ...deductionData },
     })
 
     return reply.status(201).send(override)
@@ -370,6 +488,108 @@ export async function jobRoutes(fastify: FastifyInstance) {
     if (!existing) return reply.status(404).send({ error: 'Override not found' })
 
     await prisma.monthlyIncomeOverride.delete({ where: { id: overrideId } })
+    return reply.status(204).send()
+  })
+
+  // ── Tax card settings ─────────────────────────────────────────────────────────
+
+  // GET /jobs/:id/taxcard
+  fastify.get('/jobs/:id/taxcard', { preHandler: authenticate }, async (request, reply) => {
+    const { id: jobId } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const job = await assertJobOwnership(jobId, userId, role)
+    if (!job) return reply.status(404).send({ error: 'Job not found' })
+
+    const settings = await prisma.taxCardSettings.findMany({
+      where: { jobId },
+      orderBy: { effectiveFrom: 'desc' },
+    })
+
+    return reply.send(settings)
+  })
+
+  // POST /jobs/:id/taxcard
+  fastify.post('/jobs/:id/taxcard', { preHandler: authenticate }, async (request, reply) => {
+    const { id: jobId } = request.params as { id: string }
+    const { sub: userId, role } = request.user
+
+    const job = await assertJobOwnership(jobId, userId, role)
+    if (!job) return reply.status(404).send({ error: 'Job not found' })
+
+    const result = CreateTaxCardSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const {
+      effectiveFrom, traekprocent, personfradragMonthly, municipality,
+      pensionEmployeePct, pensionEmployerPct, atpAmount, bruttoItems,
+    } = result.data
+
+    const settings = await prisma.taxCardSettings.create({
+      data: {
+        jobId,
+        effectiveFrom: new Date(effectiveFrom),
+        traekprocent: new Decimal(traekprocent),
+        personfradragMonthly: new Decimal(personfradragMonthly),
+        municipality: municipality ?? null,
+        pensionEmployeePct: pensionEmployeePct != null ? new Decimal(pensionEmployeePct) : null,
+        pensionEmployerPct: pensionEmployerPct != null ? new Decimal(pensionEmployerPct) : null,
+        atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
+        bruttoItems: bruttoItems ?? undefined,
+      },
+    })
+
+    return reply.status(201).send(settings)
+  })
+
+  // PUT /jobs/:id/taxcard/:settingsId
+  fastify.put('/jobs/:id/taxcard/:settingsId', { preHandler: authenticate }, async (request, reply) => {
+    const { id: jobId, settingsId } = request.params as { id: string; settingsId: string }
+    const { sub: userId, role } = request.user
+
+    const job = await assertJobOwnership(jobId, userId, role)
+    if (!job) return reply.status(404).send({ error: 'Job not found' })
+
+    const existing = await prisma.taxCardSettings.findFirst({ where: { id: settingsId, jobId } })
+    if (!existing) return reply.status(404).send({ error: 'Tax card settings not found' })
+
+    const result = UpdateTaxCardSchema.safeParse(request.body)
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
+    }
+
+    const data = result.data
+    const updated = await prisma.taxCardSettings.update({
+      where: { id: settingsId },
+      data: {
+        ...(data.effectiveFrom !== undefined && { effectiveFrom: new Date(data.effectiveFrom) }),
+        ...(data.traekprocent !== undefined && { traekprocent: new Decimal(data.traekprocent) }),
+        ...(data.personfradragMonthly !== undefined && { personfradragMonthly: new Decimal(data.personfradragMonthly) }),
+        ...(data.municipality !== undefined && { municipality: data.municipality }),
+        ...(data.pensionEmployeePct !== undefined && { pensionEmployeePct: data.pensionEmployeePct != null ? new Decimal(data.pensionEmployeePct) : null }),
+        ...(data.pensionEmployerPct !== undefined && { pensionEmployerPct: data.pensionEmployerPct != null ? new Decimal(data.pensionEmployerPct) : null }),
+        ...(data.atpAmount !== undefined && { atpAmount: data.atpAmount != null ? new Decimal(data.atpAmount) : null }),
+        ...(data.bruttoItems !== undefined && { bruttoItems: data.bruttoItems ?? null }),
+      },
+    })
+
+    return reply.send(updated)
+  })
+
+  // DELETE /jobs/:id/taxcard/:settingsId
+  fastify.delete('/jobs/:id/taxcard/:settingsId', { preHandler: authenticate }, async (request, reply) => {
+    const { id: jobId, settingsId } = request.params as { id: string; settingsId: string }
+    const { sub: userId, role } = request.user
+
+    const job = await assertJobOwnership(jobId, userId, role)
+    if (!job) return reply.status(404).send({ error: 'Job not found' })
+
+    const existing = await prisma.taxCardSettings.findFirst({ where: { id: settingsId, jobId } })
+    if (!existing) return reply.status(404).send({ error: 'Tax card settings not found' })
+
+    await prisma.taxCardSettings.delete({ where: { id: settingsId } })
     return reply.status(204).send()
   })
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,37 @@
+// ── Payslip / deduction types ─────────────────────────────────────────────────
+
+export interface BruttoItem {
+  label: string
+  monthlyAmount: number
+}
+
+export interface OtherDeductionItem {
+  label: string
+  amount: number
+}
+
+/** Payslip deduction breakdown — present on SalaryRecord and MonthlyIncomeOverride */
+export interface DeductionFields {
+  amBidragAmount?: number | null
+  aSkattAmount?: number | null
+  pensionEmployeeAmount?: number | null
+  pensionEmployerAmount?: number | null
+  atpAmount?: number | null
+  bruttoDeductionAmount?: number | null
+  otherDeductions?: OtherDeductionItem[] | null
+  deductionsSource?: 'MANUAL' | 'CALCULATED' | null
+}
+
+export interface TaxCardSettingsData {
+  traekprocent: number
+  personfradragMonthly: number
+  municipality?: string | null
+  pensionEmployeePct?: number | null
+  pensionEmployerPct?: number | null
+  atpAmount?: number | null
+  bruttoItems?: BruttoItem[] | null
+}
+
 export const Frequency = {
   WEEKLY: 'WEEKLY',
   FORTNIGHTLY: 'FORTNIGHTLY',

--- a/prisma/migrations/20260411000000_payslip_deductions/migration.sql
+++ b/prisma/migrations/20260411000000_payslip_deductions/migration.sql
@@ -1,0 +1,53 @@
+-- Sprint 25 (PAY-001): Payslip deduction breakdown
+-- Adds country to Job, TaxCardSettings model,
+-- and deduction fields to SalaryRecord + MonthlyIncomeOverride.
+
+-- #169 – country on Job
+ALTER TABLE "Job" ADD COLUMN "country" TEXT NOT NULL DEFAULT 'DK';
+
+-- #171 – deduction breakdown on SalaryRecord
+ALTER TABLE "SalaryRecord"
+  ADD COLUMN "amBidragAmount"        DECIMAL(10,2),
+  ADD COLUMN "aSkattAmount"          DECIMAL(10,2),
+  ADD COLUMN "pensionEmployeeAmount" DECIMAL(10,2),
+  ADD COLUMN "pensionEmployerAmount" DECIMAL(10,2),
+  ADD COLUMN "atpAmount"             DECIMAL(10,2),
+  ADD COLUMN "bruttoDeductionAmount" DECIMAL(10,2),
+  ADD COLUMN "otherDeductions"       JSONB,
+  ADD COLUMN "deductionsSource"      TEXT;
+
+-- #172 – deduction breakdown on MonthlyIncomeOverride
+ALTER TABLE "MonthlyIncomeOverride"
+  ADD COLUMN "amBidragAmount"        DECIMAL(10,2),
+  ADD COLUMN "aSkattAmount"          DECIMAL(10,2),
+  ADD COLUMN "pensionEmployeeAmount" DECIMAL(10,2),
+  ADD COLUMN "pensionEmployerAmount" DECIMAL(10,2),
+  ADD COLUMN "atpAmount"             DECIMAL(10,2),
+  ADD COLUMN "bruttoDeductionAmount" DECIMAL(10,2),
+  ADD COLUMN "otherDeductions"       JSONB,
+  ADD COLUMN "deductionsSource"      TEXT;
+
+-- #170 – TaxCardSettings model
+CREATE TABLE "TaxCardSettings" (
+  "id"                   TEXT NOT NULL,
+  "jobId"                TEXT NOT NULL,
+  "effectiveFrom"        TIMESTAMP(3) NOT NULL,
+  "traekprocent"         DECIMAL(5,2) NOT NULL,
+  "personfradragMonthly" DECIMAL(10,2) NOT NULL,
+  "municipality"         TEXT,
+  "pensionEmployeePct"   DECIMAL(5,2),
+  "pensionEmployerPct"   DECIMAL(5,2),
+  "atpAmount"            DECIMAL(10,2),
+  "bruttoItems"          JSONB,
+  "createdAt"            TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "TaxCardSettings_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "TaxCardSettings"
+  ADD CONSTRAINT "TaxCardSettings_jobId_fkey"
+  FOREIGN KEY ("jobId") REFERENCES "Job"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "TaxCardSettings_jobId_effectiveFrom_idx"
+  ON "TaxCardSettings"("jobId", "effectiveFrom");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -184,6 +184,7 @@ model Job {
   userId     String
   name       String
   employer   String?
+  country    String    @default("DK")
   startDate  DateTime
   endDate    DateTime?
   createdAt  DateTime  @default(now())
@@ -193,6 +194,7 @@ model Job {
   overrides       MonthlyIncomeOverride[]
   bonuses         Bonus[]
   allocations     HouseholdIncomeAllocation[]
+  taxCardSettings TaxCardSettings[]
 }
 
 model SalaryRecord {
@@ -204,6 +206,15 @@ model SalaryRecord {
   effectiveFrom  DateTime
   currencyCode   String?
   rateUsed       Decimal? @db.Decimal(18, 6)
+  // Payslip deduction breakdown
+  amBidragAmount        Decimal? @db.Decimal(10, 2)
+  aSkattAmount          Decimal? @db.Decimal(10, 2)
+  pensionEmployeeAmount Decimal? @db.Decimal(10, 2)
+  pensionEmployerAmount Decimal? @db.Decimal(10, 2)
+  atpAmount             Decimal? @db.Decimal(10, 2)
+  bruttoDeductionAmount Decimal? @db.Decimal(10, 2)
+  otherDeductions       Json?
+  deductionsSource      String?
   createdAt      DateTime @default(now())
 
   @@index([jobId, effectiveFrom])
@@ -218,6 +229,15 @@ model MonthlyIncomeOverride {
   grossAmount Decimal  @db.Decimal(10, 2)
   netAmount   Decimal  @db.Decimal(10, 2)
   note        String?
+  // Payslip deduction breakdown
+  amBidragAmount        Decimal? @db.Decimal(10, 2)
+  aSkattAmount          Decimal? @db.Decimal(10, 2)
+  pensionEmployeeAmount Decimal? @db.Decimal(10, 2)
+  pensionEmployerAmount Decimal? @db.Decimal(10, 2)
+  atpAmount             Decimal? @db.Decimal(10, 2)
+  bruttoDeductionAmount Decimal? @db.Decimal(10, 2)
+  otherDeductions       Json?
+  deductionsSource      String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -249,6 +269,23 @@ model HouseholdIncomeAllocation {
   allocationPct Decimal    @db.Decimal(5, 2)
 
   @@unique([jobId, budgetYearId])
+}
+
+model TaxCardSettings {
+  id                   String   @id @default(cuid())
+  job                  Job      @relation(fields: [jobId], references: [id])
+  jobId                String
+  effectiveFrom        DateTime
+  traekprocent         Decimal  @db.Decimal(5, 2)
+  personfradragMonthly Decimal  @db.Decimal(10, 2)
+  municipality         String?
+  pensionEmployeePct   Decimal? @db.Decimal(5, 2)
+  pensionEmployerPct   Decimal? @db.Decimal(5, 2)
+  atpAmount            Decimal? @db.Decimal(10, 2)
+  bruttoItems          Json?
+  createdAt            DateTime @default(now())
+
+  @@index([jobId, effectiveFrom])
 }
 
 model Category {


### PR DESCRIPTION
## Summary

- Adds `Job.country` field (default `"DK"`) to enable country-specific payslip logic in later sprints
- New `TaxCardSettings` model — effective-dated per-job tax card config (trækprocent, personfradrag, pension %, ATP, bruttolønsordning items)
- `SalaryRecord` gains 8 optional deduction fields (`amBidragAmount`, `aSkattAmount`, `pensionEmployee/EmployerAmount`, `atpAmount`, `bruttoDeductionAmount`, `otherDeductions` JSON, `deductionsSource`)
- `MonthlyIncomeOverride` mirrors the same deduction fields for per-month payslip entry
- New CRUD API: `GET/POST/PUT/DELETE /jobs/:id/taxcard`
- Shared types: `BruttoItem`, `DeductionFields`, `TaxCardSettingsData`

Closes #169, #170, #171, #172 (Sprint 25 — PAY-001)

## Test plan

- [ ] `POST /users/:id/jobs` with `country: "SE"` — stored and returned correctly; existing jobs default to `"DK"`
- [ ] `POST /jobs/:id/taxcard` — creates a `TaxCardSettings` record; `GET` returns it ordered by `effectiveFrom` desc
- [ ] `bruttoItems` JSON array stored and returned verbatim
- [ ] `PUT /jobs/:id/taxcard/:id` — partial update works; `DELETE` removes the record
- [ ] `POST /jobs/:id/salary` with deduction fields — all fields stored; `deductionsSource: "MANUAL"` preserved
- [ ] Net amount mismatch (outside ±1 DKK) → 400 with `netAmount` validation error
- [ ] Net amount omitted with no deduction fields → existing behaviour unchanged
- [ ] `POST /jobs/:id/overrides` with deduction fields — stored correctly in `MonthlyIncomeOverride`
- [ ] Auth: users cannot access another user's tax card settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)