### PR TITLE
feat(income): payslip deduction breakdown — Sprints 25–27 + data rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.53.0] - 2026-04-11 — Payslip data structure rework + Danish tax calculation fix
+
+### Changed
+- **`payslipLines` replaces seven individual deduction columns** — `SalaryRecord` and `MonthlyIncomeOverride` now store deductions as a typed JSON array of `PayslipLine` objects (`{ label, amount, type, sankeyGroup, isCalculated }`) instead of seven separate `Decimal?` columns (`amBidragAmount`, `aSkattAmount`, `pensionEmployeeAmount`, `pensionEmployerAmount`, `atpAmount`, `bruttoDeductionAmount`, `otherDeductions`); supports arbitrary payslip structures, benefit-in-kind lines, and future line types without schema changes
+- **`pensionEmployerMonthly` is now a dedicated field** — employer pension was previously stored alongside employee deductions; separated to make clear it is an employer cost not deducted from net pay
+- **Sankey endpoint aggregates from `payslipLines.sankeyGroup`** — deduction node values are computed by summing lines that share the same `sankeyGroup`, making it trivial to add new line types without touching the Sankey logic
+
+### Fixed
+- **Critical: pension employee and ATP are pre-AM deductions** — both were incorrectly calculated on full gross after AM-bidrag; they now reduce the AM-indkomst base *before* AM-bidrag is applied, matching real Danish payroll (SKAT rules); this affected all auto-calculated records
+- **AM-bidrag and A-skat now truncate to whole DKK** — real Danish payroll systems floor (not round) both tax amounts; switched `Math.round` → `Math.floor` for these two lines
+- **Calculated net always overwrites manually entered net** — when a tax card is present, the auto-calculated `net` value is stored unconditionally; a stale manually entered net from before a tax card was added can no longer persist after a re-save
+- **Tax card records are now editable in the frontend** — an Edit button on each tax card row pre-fills the form and calls `PUT /jobs/:id/taxcard/:settingsId`; previously only create was exposed in the UI
+
+### Migration
+- Drops old seven deduction columns, adds `payslipLines JSONB` and `pensionEmployerMonthly DECIMAL(10,2)`; resets `deductionsSource = NULL` on all existing rows so they are recalculated (with the corrected formula) on the next save
+
+---
+
+## [0.52.0] - 2026-04-11 — Payslip deduction UI (Sprint 27)
+
+### Added
+- **Country selector on job create/edit form** (#176) — jobs now show a country dropdown (DK default); selecting DK enables tax-card and deduction features; other countries hide the DK-specific sections
+- **Tax card settings form per job** (#177) — collapsible section on each DK job card; add/view tax card records (effective-dated); shows active badge on the current card; fields: trækprocent, personfradrag/month, municipality label, employee/employer pension %, ATP override, and a dynamic bruttolønsordning item list
+- **Enhanced salary record form with deduction breakdown** (#178) — DK jobs show a `DeductionPanel` below the gross amount field; panel displays auto-calculated lines (AM-bidrag, A-skat, ATP, pension employee) with a ✏ override button per line; override resets with ↺; net pay shown live; no tax card shows a prompt to add one
+- **Monthly override with deduction section** (#179) — the add-override modal gains a collapsible deduction section mirroring the salary form panel; overrides are per-field and cleared on close
+- **3-column Sankey visualisation** (#180) — when any active salary record has deduction data the Sankey switches to a 3-column layout: Jobs → deduction nodes (AM-bidrag, A-skat, Pension employee, ATP, Brutto benefits, Other) + Net Pay → Expenses / Savings / Surplus / Unallocated; employer pension info row shown below the chart when present; layout falls back to 2-column when no deduction data exists
+
+---
+
+## [0.51.0] - 2026-04-11 — Danish tax engine & auto-calculation on save (Sprint 26)
+
+### Added
+- **Danish payroll tax calculation engine** (`taxCalcDK.ts`) (#173) — server-side calculation of AM-bidrag, A-skat (with top-skat), ATP, employee/employer pension, and net pay from a gross salary and active `TaxCardSettings` record; 2024 constants (top-skat threshold 49,075 DKK/month, top-skat rate 15%, AM-bidrag 8%, default ATP 99 DKK)
+- **Auto-calculate deductions on salary record save** (#174) — `POST /jobs/:id/salary` and `PUT /jobs/:id/salary/:salaryId` call `resolveDeductions()` which: (1) uses explicit client-supplied deduction fields if present (MANUAL), (2) auto-calculates from the active tax card if the job is DK and a card exists (CALCULATED), or (3) stores no deductions (fallback); same logic applies to `POST /jobs/:id/overrides`
+- **Granular Sankey endpoint** (#175) — `GET /users/me/income/sankey` detects whether any active salary/override record has `deductionsSource != null` and switches between a 3-column granular layout (Jobs → AM-bidrag, A-skat, Pension, ATP, Brutto, Other Deductions, Net Pay → right side) and the previous 2-column fallback; returns `employerPensionMonthly` metadata when employer pension is set
+- **`calcDanishDeductions` in shared package** — mirrors the API engine for frontend live-preview use; exported from `packages/shared` along with `TaxCalcInput` and `TaxCalcResult` types
+
+---
+
 ## [0.50.0] - 2026-04-11 — Payslip income breakdown: data foundation (Sprint 25)
 
 ### Added

--- a/apps/api/src/lib/taxCalcDK.ts
+++ b/apps/api/src/lib/taxCalcDK.ts
@@ -1,0 +1,106 @@
+/**
+ * Danish payroll tax calculation engine.
+ *
+ * Hardcoded 2024 tax constants — update annually:
+ *   - Top-skat threshold:  588,900 DKK/year  → 49,075 DKK/month
+ *   - Top-skat rate:       15%
+ *   - AM-bidrag rate:      8%
+ *   - Default ATP:         99 DKK/month (full-time 2024 rate)
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface BruttoItem {
+  label: string
+  monthlyAmount: number
+}
+
+export interface TaxCardInput {
+  traekprocent: number          // municipal + state bottom tax rate, e.g. 38
+  personfradragMonthly: number  // personal deduction, e.g. 3875
+  pensionEmployeePct?: number | null
+  pensionEmployerPct?: number | null
+  atpAmount?: number | null
+  bruttoItems?: BruttoItem[] | null
+}
+
+export interface DeductionBreakdown {
+  amBidrag: number
+  aSkat: number
+  /** Top-skat component already included inside aSkat */
+  topSkat: number
+  atp: number
+  pensionEmployee: number
+  pensionEmployer: number
+  bruttoTotal: number
+  bruttoItems: BruttoItem[]
+  net: number
+  /** Always true — calculation uses trækprocent directly, not marginal rate tables */
+  isApproximate: true
+}
+
+// ── Constants (2024) ──────────────────────────────────────────────────────────
+
+/** 588,900 DKK/year ÷ 12 */
+const TOP_SKAT_MONTHLY_THRESHOLD = 49_075
+const TOP_SKAT_RATE = 0.15
+const AM_BIDRAG_RATE = 0.08
+const DEFAULT_ATP = 99 // DKK/month, full-time 2024
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+// ── Core calculation ──────────────────────────────────────────────────────────
+
+/**
+ * Calculate Danish payroll deductions for a given gross monthly salary.
+ *
+ * Calculation order:
+ *   1. Bruttolønsordning reduces taxable base (tax-advantaged)
+ *   2. AM-bidrag (8% of taxable gross)
+ *   3. A-skat = bottom tax (trækprocent after personfradrag) + top-skat (15% above threshold)
+ *   4. ATP and pension calculated on full gross (not taxable gross)
+ */
+export function calcDanishDeductions(gross: number, settings: TaxCardInput): DeductionBreakdown {
+  // Step 1: Bruttolønsordning — reduce taxable base
+  const bruttoItems = settings.bruttoItems ?? []
+  const bruttoTotal = round2(bruttoItems.reduce((s, i) => s + i.monthlyAmount, 0))
+  const taxableGross = gross - bruttoTotal
+
+  // Step 2: AM-bidrag — always 8% of taxable gross
+  const amBidrag = round2(taxableGross * AM_BIDRAG_RATE)
+  const aIndkomst = taxableGross - amBidrag
+
+  // Step 3: A-skat — bottom tax + top-skat
+  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
+  const bottomTax = round2(taxableBase * settings.traekprocent / 100)
+  const topSkat = round2(Math.max(0, aIndkomst - TOP_SKAT_MONTHLY_THRESHOLD) * TOP_SKAT_RATE)
+  const aSkat = bottomTax + topSkat
+
+  // Step 4: ATP and pension — calculated on full gross
+  const atp = round2(settings.atpAmount ?? DEFAULT_ATP)
+  const pensionEmployee = settings.pensionEmployeePct
+    ? round2(gross * settings.pensionEmployeePct / 100)
+    : 0
+  const pensionEmployer = settings.pensionEmployerPct
+    ? round2(gross * settings.pensionEmployerPct / 100)
+    : 0
+
+  const net = round2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
+
+  return {
+    amBidrag,
+    aSkat,
+    topSkat,
+    atp,
+    pensionEmployee,
+    pensionEmployer,
+    bruttoTotal,
+    bruttoItems,
+    net,
+    isApproximate: true,
+  }
+}

--- a/apps/api/src/lib/taxCalcDK.ts
+++ b/apps/api/src/lib/taxCalcDK.ts
@@ -24,16 +24,22 @@ export interface TaxCardInput {
   bruttoItems?: BruttoItem[] | null
 }
 
-export interface DeductionBreakdown {
-  amBidrag: number
-  aSkat: number
-  /** Top-skat component already included inside aSkat */
-  topSkat: number
-  atp: number
-  pensionEmployee: number
+export type PayslipLineType = 'benefit_in_kind' | 'pre_am' | 'am_bidrag' | 'a_skat' | 'post_tax'
+export type SankeyGroup = 'brutto_benefits' | 'am_bidrag' | 'a_skat' | 'pension_employee' | 'atp' | 'other_deductions'
+
+export interface PayslipLine {
+  label: string
+  /** Positive — deduction or benefit amount */
+  amount: number
+  type: PayslipLineType
+  /** Which Sankey node this line aggregates into */
+  sankeyGroup?: SankeyGroup
+  isCalculated: boolean
+}
+
+export interface DeductionResult {
+  lines: PayslipLine[]
   pensionEmployer: number
-  bruttoTotal: number
-  bruttoItems: BruttoItem[]
   net: number
   /** Always true — calculation uses trækprocent directly, not marginal rate tables */
   isApproximate: true
@@ -58,49 +64,79 @@ function round2(n: number): number {
 /**
  * Calculate Danish payroll deductions for a given gross monthly salary.
  *
- * Calculation order:
- *   1. Bruttolønsordning reduces taxable base (tax-advantaged)
- *   2. AM-bidrag (8% of taxable gross)
+ * Correct calculation order (matching real Danish payroll):
+ *   1. Pre-AM deductions: bruttolønsordning items + pension employee % + ATP
+ *      → all reduce AM-indkomst (the base for AM-bidrag)
+ *   2. AM-bidrag = 8% of AM-indkomst, truncated to whole DKK
  *   3. A-skat = bottom tax (trækprocent after personfradrag) + top-skat (15% above threshold)
- *   4. ATP and pension calculated on full gross (not taxable gross)
+ *      → both truncated to whole DKK, matching real payroll systems
+ *   4. Net = gross − preAmTotal − amBidrag − aSkat
+ *
+ * Pension employer contribution is returned separately — it is an employer cost
+ * only and does not appear on the employee's net pay.
  */
-export function calcDanishDeductions(gross: number, settings: TaxCardInput): DeductionBreakdown {
-  // Step 1: Bruttolønsordning — reduce taxable base
+export function calcDanishDeductions(gross: number, settings: TaxCardInput): DeductionResult {
+  const lines: PayslipLine[] = []
+
+  // ── Step 1: Pre-AM deductions (reduce AM base) ─────────────────────────────
   const bruttoItems = settings.bruttoItems ?? []
   const bruttoTotal = round2(bruttoItems.reduce((s, i) => s + i.monthlyAmount, 0))
-  const taxableGross = gross - bruttoTotal
 
-  // Step 2: AM-bidrag — always 8% of taxable gross
-  const amBidrag = round2(taxableGross * AM_BIDRAG_RATE)
-  const aIndkomst = taxableGross - amBidrag
+  for (const item of bruttoItems) {
+    lines.push({
+      label: item.label,
+      amount: item.monthlyAmount,
+      type: 'pre_am',
+      sankeyGroup: 'brutto_benefits',
+      isCalculated: true,
+    })
+  }
 
-  // Step 3: A-skat — bottom tax + top-skat
-  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
-  const bottomTax = round2(taxableBase * settings.traekprocent / 100)
-  const topSkat = round2(Math.max(0, aIndkomst - TOP_SKAT_MONTHLY_THRESHOLD) * TOP_SKAT_RATE)
-  const aSkat = bottomTax + topSkat
-
-  // Step 4: ATP and pension — calculated on full gross
-  const atp = round2(settings.atpAmount ?? DEFAULT_ATP)
   const pensionEmployee = settings.pensionEmployeePct
     ? round2(gross * settings.pensionEmployeePct / 100)
     : 0
+  if (pensionEmployee > 0) {
+    lines.push({
+      label: 'Pension (employee)',
+      amount: pensionEmployee,
+      type: 'pre_am',
+      sankeyGroup: 'pension_employee',
+      isCalculated: true,
+    })
+  }
+
+  const atp = Math.floor(settings.atpAmount ?? DEFAULT_ATP)
+  if (atp > 0) {
+    lines.push({ label: 'ATP', amount: atp, type: 'pre_am', sankeyGroup: 'atp', isCalculated: true })
+  }
+
+  const preAmTotal = round2(bruttoTotal + pensionEmployee + atp)
+
+  // ── Step 2: AM-bidrag — 8% of AM-indkomst, truncated ──────────────────────
+  const amBase = gross - preAmTotal
+  const amBidrag = Math.floor(amBase * AM_BIDRAG_RATE)
+  lines.push({ label: 'AM-bidrag (8%)', amount: amBidrag, type: 'am_bidrag', sankeyGroup: 'am_bidrag', isCalculated: true })
+
+  // ── Step 3: A-skat — truncated to whole DKK ───────────────────────────────
+  const aIndkomst = amBase - amBidrag
+  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
+  const bottomTax = Math.floor(taxableBase * settings.traekprocent / 100)
+  const topSkat = Math.floor(Math.max(0, aIndkomst - TOP_SKAT_MONTHLY_THRESHOLD) * TOP_SKAT_RATE)
+  const aSkat = bottomTax + topSkat
+  lines.push({
+    label: topSkat > 0 ? `A-skat (incl. top-skat ${topSkat})` : 'A-skat',
+    amount: aSkat,
+    type: 'a_skat',
+    sankeyGroup: 'a_skat',
+    isCalculated: true,
+  })
+
+  // ── Pension employer (employer cost only, not deducted from net) ───────────
   const pensionEmployer = settings.pensionEmployerPct
     ? round2(gross * settings.pensionEmployerPct / 100)
     : 0
 
-  const net = round2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
+  const net = round2(gross - preAmTotal - amBidrag - aSkat)
 
-  return {
-    amBidrag,
-    aSkat,
-    topSkat,
-    atp,
-    pensionEmployee,
-    pensionEmployer,
-    bruttoTotal,
-    bruttoItems,
-    net,
-    isApproximate: true,
-  }
+  return { lines, pensionEmployer, net, isApproximate: true }
 }

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -7,7 +7,7 @@ import { getJobMonthlyIncome, getIncomeReferenceDate } from '../lib/incomeCalc'
 import { getLatestRate, BASE_CURRENCY } from '../lib/currency'
 import { assertHouseholdAccess } from '../lib/ownership'
 import { toNum } from '../lib/decimal'
-import { calcDanishDeductions } from '../lib/taxCalcDK'
+import { calcDanishDeductions, PayslipLine } from '../lib/taxCalcDK'
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 
@@ -24,19 +24,16 @@ const UpdateJobSchema = CreateJobSchema.partial().refine(
   { message: 'At least one field is required' }
 )
 
-const OtherDeductionItemSchema = z.object({
-  label: z.string().min(1).max(100),
+const PayslipLineSchema = z.object({
+  label: z.string().min(1).max(200),
   amount: z.number().nonnegative(),
+  type: z.enum(['benefit_in_kind', 'pre_am', 'am_bidrag', 'a_skat', 'post_tax']),
+  sankeyGroup: z.enum(['brutto_benefits', 'am_bidrag', 'a_skat', 'pension_employee', 'atp', 'other_deductions']).optional(),
+  isCalculated: z.boolean(),
 })
 
 const DeductionFieldsSchema = z.object({
-  amBidragAmount: z.number().nonnegative().optional(),
-  aSkattAmount: z.number().nonnegative().optional(),
-  pensionEmployeeAmount: z.number().nonnegative().optional(),
-  pensionEmployerAmount: z.number().nonnegative().optional(),
-  atpAmount: z.number().nonnegative().optional(),
-  bruttoDeductionAmount: z.number().nonnegative().optional(),
-  otherDeductions: z.array(OtherDeductionItemSchema).optional(),
+  payslipLines: z.array(PayslipLineSchema).optional(),
   deductionsSource: z.enum(['MANUAL', 'CALCULATED']).optional(),
 })
 
@@ -46,18 +43,12 @@ function validateDeductionNet(
   d: z.infer<typeof DeductionFieldsSchema>,
   ctx: z.RefinementCtx
 ) {
-  const hasDeductions =
-    d.amBidragAmount !== undefined ||
-    d.aSkattAmount !== undefined ||
-    d.bruttoDeductionAmount !== undefined
-  if (!hasDeductions) return
-  const brutto = d.bruttoDeductionAmount ?? 0
-  const amBidrag = d.amBidragAmount ?? 0
-  const aSkat = d.aSkattAmount ?? 0
-  const pensionEmp = d.pensionEmployeeAmount ?? 0
-  const atp = d.atpAmount ?? 0
-  const other = (d.otherDeductions ?? []).reduce((s, i) => s + i.amount, 0)
-  const expectedNet = grossAmount - brutto - amBidrag - aSkat - pensionEmp - atp - other
+  if (!d.payslipLines || d.payslipLines.length === 0) return
+  // benefit_in_kind lines add to taxable income but are not cash deductions
+  const cashDeductions = d.payslipLines
+    .filter((l) => l.type !== 'benefit_in_kind')
+    .reduce((s, l) => s + l.amount, 0)
+  const expectedNet = grossAmount - cashDeductions
   if (Math.abs(expectedNet - netAmount) > 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -159,51 +150,31 @@ async function assertJobOwnership(jobId: string, requesterId: string, requesterR
  * Resolve deduction data for a salary record or monthly override.
  *
  * Priority:
- *   1. Explicit deduction fields in request → store verbatim, source = MANUAL
+ *   1. Explicit payslipLines in request → store verbatim, source = MANUAL
  *   2. Job is DK + active tax card exists → auto-calculate, source = CALCULATED
- *   3. Fallback → all null (legacy behaviour)
+ *   3. Fallback → all null (legacy behaviour, no deduction data stored)
  */
 async function resolveDeductions(
   jobId: string,
   jobCountry: string,
   gross: number,
-  requestFields: {
-    amBidragAmount?: number
-    aSkattAmount?: number
-    pensionEmployeeAmount?: number
-    pensionEmployerAmount?: number
-    atpAmount?: number
-    bruttoDeductionAmount?: number
-    otherDeductions?: { label: string; amount: number }[]
-    deductionsSource?: 'MANUAL' | 'CALCULATED'
-  }
+  requestPayslipLines?: PayslipLine[]
 ): Promise<{
-  amBidragAmount: Decimal | null
-  aSkattAmount: Decimal | null
-  pensionEmployeeAmount: Decimal | null
-  pensionEmployerAmount: Decimal | null
-  atpAmount: Decimal | null
-  bruttoDeductionAmount: Decimal | null
-  otherDeductions: { label: string; amount: number }[] | null
+  payslipLines: PayslipLine[] | null
+  pensionEmployerMonthly: Decimal | null
   deductionsSource: string | null
   netAmount: Decimal | null  // null means "use request netAmount as-is"
 }> {
-  const hasExplicitDeductions =
-    requestFields.amBidragAmount !== undefined ||
-    requestFields.aSkattAmount !== undefined ||
-    requestFields.bruttoDeductionAmount !== undefined
-
-  if (hasExplicitDeductions || requestFields.deductionsSource === 'MANUAL') {
+  if (requestPayslipLines && requestPayslipLines.length > 0) {
+    // MANUAL: user submitted explicit payslip lines
+    const cashDeductions = requestPayslipLines
+      .filter((l) => l.type !== 'benefit_in_kind')
+      .reduce((s, l) => s + l.amount, 0)
     return {
-      amBidragAmount: requestFields.amBidragAmount != null ? new Decimal(requestFields.amBidragAmount) : null,
-      aSkattAmount: requestFields.aSkattAmount != null ? new Decimal(requestFields.aSkattAmount) : null,
-      pensionEmployeeAmount: requestFields.pensionEmployeeAmount != null ? new Decimal(requestFields.pensionEmployeeAmount) : null,
-      pensionEmployerAmount: requestFields.pensionEmployerAmount != null ? new Decimal(requestFields.pensionEmployerAmount) : null,
-      atpAmount: requestFields.atpAmount != null ? new Decimal(requestFields.atpAmount) : null,
-      bruttoDeductionAmount: requestFields.bruttoDeductionAmount != null ? new Decimal(requestFields.bruttoDeductionAmount) : null,
-      otherDeductions: requestFields.otherDeductions ?? null,
+      payslipLines: requestPayslipLines,
+      pensionEmployerMonthly: null,
       deductionsSource: 'MANUAL',
-      netAmount: null,
+      netAmount: new Decimal(Math.round((gross - cashDeductions) * 100) / 100),
     }
   }
 
@@ -222,13 +193,8 @@ async function resolveDeductions(
         bruttoItems: taxCard.bruttoItems as { label: string; monthlyAmount: number }[] | null,
       })
       return {
-        amBidragAmount: new Decimal(calc.amBidrag),
-        aSkattAmount: new Decimal(calc.aSkat),
-        pensionEmployeeAmount: calc.pensionEmployee > 0 ? new Decimal(calc.pensionEmployee) : null,
-        pensionEmployerAmount: calc.pensionEmployer > 0 ? new Decimal(calc.pensionEmployer) : null,
-        atpAmount: new Decimal(calc.atp),
-        bruttoDeductionAmount: calc.bruttoTotal > 0 ? new Decimal(calc.bruttoTotal) : null,
-        otherDeductions: null,
+        payslipLines: calc.lines,
+        pensionEmployerMonthly: calc.pensionEmployer > 0 ? new Decimal(calc.pensionEmployer) : null,
         deductionsSource: 'CALCULATED',
         netAmount: new Decimal(calc.net),
       }
@@ -237,13 +203,8 @@ async function resolveDeductions(
 
   // Fallback: no deduction data
   return {
-    amBidragAmount: null,
-    aSkattAmount: null,
-    pensionEmployeeAmount: null,
-    pensionEmployerAmount: null,
-    atpAmount: null,
-    bruttoDeductionAmount: null,
-    otherDeductions: null,
+    payslipLines: null,
+    pensionEmployerMonthly: null,
     deductionsSource: null,
     netAmount: null,
   }
@@ -412,21 +373,14 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const {
-      grossAmount, netAmount, effectiveFrom, currencyCode,
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    } = result.data
+    const { grossAmount, netAmount, effectiveFrom, currencyCode, payslipLines } = result.data
     const currency = currencyCode && currencyCode !== BASE_CURRENCY ? currencyCode : null
     const rate = currency ? await getLatestRate(currency) : null
     if (currency && rate === null) {
       return reply.status(400).send({ error: `No exchange rate found for ${currency}` })
     }
 
-    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    })
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, payslipLines as PayslipLine[] | undefined)
 
     const record = await prisma.salaryRecord.create({
       data: {
@@ -436,13 +390,9 @@ export async function jobRoutes(fastify: FastifyInstance) {
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
-        amBidragAmount: deductions.amBidragAmount,
-        aSkattAmount: deductions.aSkattAmount,
-        pensionEmployeeAmount: deductions.pensionEmployeeAmount,
-        pensionEmployerAmount: deductions.pensionEmployerAmount,
-        atpAmount: deductions.atpAmount,
-        bruttoDeductionAmount: deductions.bruttoDeductionAmount,
-        otherDeductions: deductions.otherDeductions ?? undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payslipLines: deductions.payslipLines ? (deductions.payslipLines as any) : undefined,
+        pensionEmployerMonthly: deductions.pensionEmployerMonthly,
         deductionsSource: deductions.deductionsSource,
       },
     })
@@ -466,21 +416,14 @@ export async function jobRoutes(fastify: FastifyInstance) {
     const existing = await prisma.salaryRecord.findFirst({ where: { id: salaryId, jobId } })
     if (!existing) return reply.status(404).send({ error: 'Salary record not found' })
 
-    const {
-      grossAmount, netAmount, effectiveFrom, currencyCode,
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    } = result.data
+    const { grossAmount, netAmount, effectiveFrom, currencyCode, payslipLines } = result.data
     const currency = currencyCode && currencyCode !== BASE_CURRENCY ? currencyCode : null
     const rate = currency ? await getLatestRate(currency) : null
     if (currency && rate === null) {
       return reply.status(400).send({ error: `No exchange rate found for ${currency}` })
     }
 
-    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    })
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, payslipLines as PayslipLine[] | undefined)
 
     const record = await prisma.salaryRecord.update({
       where: { id: salaryId },
@@ -490,13 +433,9 @@ export async function jobRoutes(fastify: FastifyInstance) {
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
-        amBidragAmount: deductions.amBidragAmount,
-        aSkattAmount: deductions.aSkattAmount,
-        pensionEmployeeAmount: deductions.pensionEmployeeAmount,
-        pensionEmployerAmount: deductions.pensionEmployerAmount,
-        atpAmount: deductions.atpAmount,
-        bruttoDeductionAmount: deductions.bruttoDeductionAmount,
-        otherDeductions: deductions.otherDeductions ?? undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payslipLines: deductions.payslipLines ? (deductions.payslipLines as any) : undefined,
+        pensionEmployerMonthly: deductions.pensionEmployerMonthly,
         deductionsSource: deductions.deductionsSource,
       },
     })
@@ -555,26 +494,15 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: 'Invalid request body', details: result.error.flatten() })
     }
 
-    const {
-      year, month, grossAmount, netAmount, note,
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    } = result.data
+    const { year, month, grossAmount, netAmount, note, payslipLines } = result.data
 
-    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
-      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
-      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
-    })
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, payslipLines as PayslipLine[] | undefined)
 
     const resolvedNet = deductions.netAmount ?? new Decimal(netAmount)
-    const deductionData = {
-      amBidragAmount: deductions.amBidragAmount,
-      aSkattAmount: deductions.aSkattAmount,
-      pensionEmployeeAmount: deductions.pensionEmployeeAmount,
-      pensionEmployerAmount: deductions.pensionEmployerAmount,
-      atpAmount: deductions.atpAmount,
-      bruttoDeductionAmount: deductions.bruttoDeductionAmount,
-      otherDeductions: deductions.otherDeductions ?? undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deductionData: any = {
+      payslipLines: deductions.payslipLines ?? undefined,
+      pensionEmployerMonthly: deductions.pensionEmployerMonthly,
       deductionsSource: deductions.deductionsSource,
     }
 

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -7,6 +7,7 @@ import { getJobMonthlyIncome, getIncomeReferenceDate } from '../lib/incomeCalc'
 import { getLatestRate, BASE_CURRENCY } from '../lib/currency'
 import { assertHouseholdAccess } from '../lib/ownership'
 import { toNum } from '../lib/decimal'
+import { calcDanishDeductions } from '../lib/taxCalcDK'
 
 // ── Schemas ───────────────────────────────────────────────────────────────────
 
@@ -152,6 +153,100 @@ async function assertJobOwnership(jobId: string, requesterId: string, requesterR
   // Bookkeeper or admin: may only access proxy users' jobs
   if (['SYSTEM_ADMIN', 'BOOKKEEPER'].includes(requesterRole) && job.user.isProxy) return job
   return null
+}
+
+/**
+ * Resolve deduction data for a salary record or monthly override.
+ *
+ * Priority:
+ *   1. Explicit deduction fields in request → store verbatim, source = MANUAL
+ *   2. Job is DK + active tax card exists → auto-calculate, source = CALCULATED
+ *   3. Fallback → all null (legacy behaviour)
+ */
+async function resolveDeductions(
+  jobId: string,
+  jobCountry: string,
+  gross: number,
+  requestFields: {
+    amBidragAmount?: number
+    aSkattAmount?: number
+    pensionEmployeeAmount?: number
+    pensionEmployerAmount?: number
+    atpAmount?: number
+    bruttoDeductionAmount?: number
+    otherDeductions?: { label: string; amount: number }[]
+    deductionsSource?: 'MANUAL' | 'CALCULATED'
+  }
+): Promise<{
+  amBidragAmount: Decimal | null
+  aSkattAmount: Decimal | null
+  pensionEmployeeAmount: Decimal | null
+  pensionEmployerAmount: Decimal | null
+  atpAmount: Decimal | null
+  bruttoDeductionAmount: Decimal | null
+  otherDeductions: { label: string; amount: number }[] | null
+  deductionsSource: string | null
+  netAmount: Decimal | null  // null means "use request netAmount as-is"
+}> {
+  const hasExplicitDeductions =
+    requestFields.amBidragAmount !== undefined ||
+    requestFields.aSkattAmount !== undefined ||
+    requestFields.bruttoDeductionAmount !== undefined
+
+  if (hasExplicitDeductions || requestFields.deductionsSource === 'MANUAL') {
+    return {
+      amBidragAmount: requestFields.amBidragAmount != null ? new Decimal(requestFields.amBidragAmount) : null,
+      aSkattAmount: requestFields.aSkattAmount != null ? new Decimal(requestFields.aSkattAmount) : null,
+      pensionEmployeeAmount: requestFields.pensionEmployeeAmount != null ? new Decimal(requestFields.pensionEmployeeAmount) : null,
+      pensionEmployerAmount: requestFields.pensionEmployerAmount != null ? new Decimal(requestFields.pensionEmployerAmount) : null,
+      atpAmount: requestFields.atpAmount != null ? new Decimal(requestFields.atpAmount) : null,
+      bruttoDeductionAmount: requestFields.bruttoDeductionAmount != null ? new Decimal(requestFields.bruttoDeductionAmount) : null,
+      otherDeductions: requestFields.otherDeductions ?? null,
+      deductionsSource: 'MANUAL',
+      netAmount: null,
+    }
+  }
+
+  if (jobCountry === 'DK') {
+    const taxCard = await prisma.taxCardSettings.findFirst({
+      where: { jobId, effectiveFrom: { lte: new Date() } },
+      orderBy: { effectiveFrom: 'desc' },
+    })
+    if (taxCard) {
+      const calc = calcDanishDeductions(gross, {
+        traekprocent: toNum(taxCard.traekprocent),
+        personfradragMonthly: toNum(taxCard.personfradragMonthly),
+        pensionEmployeePct: taxCard.pensionEmployeePct != null ? toNum(taxCard.pensionEmployeePct) : null,
+        pensionEmployerPct: taxCard.pensionEmployerPct != null ? toNum(taxCard.pensionEmployerPct) : null,
+        atpAmount: taxCard.atpAmount != null ? toNum(taxCard.atpAmount) : null,
+        bruttoItems: taxCard.bruttoItems as { label: string; monthlyAmount: number }[] | null,
+      })
+      return {
+        amBidragAmount: new Decimal(calc.amBidrag),
+        aSkattAmount: new Decimal(calc.aSkat),
+        pensionEmployeeAmount: calc.pensionEmployee > 0 ? new Decimal(calc.pensionEmployee) : null,
+        pensionEmployerAmount: calc.pensionEmployer > 0 ? new Decimal(calc.pensionEmployer) : null,
+        atpAmount: new Decimal(calc.atp),
+        bruttoDeductionAmount: calc.bruttoTotal > 0 ? new Decimal(calc.bruttoTotal) : null,
+        otherDeductions: null,
+        deductionsSource: 'CALCULATED',
+        netAmount: new Decimal(calc.net),
+      }
+    }
+  }
+
+  // Fallback: no deduction data
+  return {
+    amBidragAmount: null,
+    aSkattAmount: null,
+    pensionEmployeeAmount: null,
+    pensionEmployerAmount: null,
+    atpAmount: null,
+    bruttoDeductionAmount: null,
+    otherDeductions: null,
+    deductionsSource: null,
+    netAmount: null,
+  }
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -328,22 +423,27 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: `No exchange rate found for ${currency}` })
     }
 
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    })
+
     const record = await prisma.salaryRecord.create({
       data: {
         jobId,
         grossAmount: new Decimal(grossAmount),
-        netAmount: new Decimal(netAmount),
+        netAmount: deductions.netAmount ?? new Decimal(netAmount),
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
-        amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
-        aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
-        pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
-        pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
-        atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
-        bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
-        otherDeductions: otherDeductions ?? undefined,
-        deductionsSource: deductionsSource ?? null,
+        amBidragAmount: deductions.amBidragAmount,
+        aSkattAmount: deductions.aSkattAmount,
+        pensionEmployeeAmount: deductions.pensionEmployeeAmount,
+        pensionEmployerAmount: deductions.pensionEmployerAmount,
+        atpAmount: deductions.atpAmount,
+        bruttoDeductionAmount: deductions.bruttoDeductionAmount,
+        otherDeductions: deductions.otherDeductions ?? undefined,
+        deductionsSource: deductions.deductionsSource,
       },
     })
 
@@ -377,22 +477,27 @@ export async function jobRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: `No exchange rate found for ${currency}` })
     }
 
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    })
+
     const record = await prisma.salaryRecord.update({
       where: { id: salaryId },
       data: {
         grossAmount: new Decimal(grossAmount),
-        netAmount: new Decimal(netAmount),
+        netAmount: deductions.netAmount ?? new Decimal(netAmount),
         effectiveFrom: new Date(effectiveFrom),
         currencyCode: currency,
         rateUsed: rate !== null ? new Decimal(rate) : null,
-        amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
-        aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
-        pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
-        pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
-        atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
-        bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
-        otherDeductions: otherDeductions ?? undefined,
-        deductionsSource: deductionsSource ?? null,
+        amBidragAmount: deductions.amBidragAmount,
+        aSkattAmount: deductions.aSkattAmount,
+        pensionEmployeeAmount: deductions.pensionEmployeeAmount,
+        pensionEmployerAmount: deductions.pensionEmployerAmount,
+        atpAmount: deductions.atpAmount,
+        bruttoDeductionAmount: deductions.bruttoDeductionAmount,
+        otherDeductions: deductions.otherDeductions ?? undefined,
+        deductionsSource: deductions.deductionsSource,
       },
     })
 
@@ -456,21 +561,27 @@ export async function jobRoutes(fastify: FastifyInstance) {
       atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
     } = result.data
 
+    const deductions = await resolveDeductions(jobId, job.country, grossAmount, {
+      amBidragAmount, aSkattAmount, pensionEmployeeAmount, pensionEmployerAmount,
+      atpAmount, bruttoDeductionAmount, otherDeductions, deductionsSource,
+    })
+
+    const resolvedNet = deductions.netAmount ?? new Decimal(netAmount)
     const deductionData = {
-      amBidragAmount: amBidragAmount != null ? new Decimal(amBidragAmount) : null,
-      aSkattAmount: aSkattAmount != null ? new Decimal(aSkattAmount) : null,
-      pensionEmployeeAmount: pensionEmployeeAmount != null ? new Decimal(pensionEmployeeAmount) : null,
-      pensionEmployerAmount: pensionEmployerAmount != null ? new Decimal(pensionEmployerAmount) : null,
-      atpAmount: atpAmount != null ? new Decimal(atpAmount) : null,
-      bruttoDeductionAmount: bruttoDeductionAmount != null ? new Decimal(bruttoDeductionAmount) : null,
-      otherDeductions: otherDeductions ?? undefined,
-      deductionsSource: deductionsSource ?? null,
+      amBidragAmount: deductions.amBidragAmount,
+      aSkattAmount: deductions.aSkattAmount,
+      pensionEmployeeAmount: deductions.pensionEmployeeAmount,
+      pensionEmployerAmount: deductions.pensionEmployerAmount,
+      atpAmount: deductions.atpAmount,
+      bruttoDeductionAmount: deductions.bruttoDeductionAmount,
+      otherDeductions: deductions.otherDeductions ?? undefined,
+      deductionsSource: deductions.deductionsSource,
     }
 
     const override = await prisma.monthlyIncomeOverride.upsert({
       where: { jobId_year_month: { jobId, year, month } },
-      create: { jobId, year, month, grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note, ...deductionData },
-      update: { grossAmount: new Decimal(grossAmount), netAmount: new Decimal(netAmount), note, ...deductionData },
+      create: { jobId, year, month, grossAmount: new Decimal(grossAmount), netAmount: resolvedNet, note, ...deductionData },
+      update: { grossAmount: new Decimal(grossAmount), netAmount: resolvedNet, note, ...deductionData },
     })
 
     return reply.status(201).send(override)

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -177,16 +177,42 @@ export async function profileRoutes(fastify: FastifyInstance) {
   fastify.get('/users/me/income/sankey', { preHandler: authenticate }, async (request, reply) => {
     const { sub: userId } = request.user
     const today = new Date()
+    const year = today.getFullYear()
+    const month = today.getMonth() + 1
 
     // Fetch active jobs
     const activeJobs = await prisma.job.findMany({
       where: { userId, endDate: null },
     })
 
+    // Fetch income + active salary/override record (with deduction fields) per job
     const jobIncomes = await Promise.all(
       activeJobs.map(async (job) => {
         const { gross, net } = await getJobMonthlyIncome(job.id, today)
-        return { job, gross, net }
+
+        // Get the active record to check for deduction data
+        const override = await prisma.monthlyIncomeOverride.findUnique({
+          where: { jobId_year_month: { jobId: job.id, year, month } },
+        })
+        const record = override ?? await prisma.salaryRecord.findFirst({
+          where: { jobId: job.id, effectiveFrom: { lte: today } },
+          orderBy: { effectiveFrom: 'desc' },
+        })
+
+        const hasDeductions = record?.deductionsSource != null
+        const deductions = hasDeductions && record ? {
+          amBidrag: record.amBidragAmount ? toNum(record.amBidragAmount) : 0,
+          aSkat: record.aSkattAmount ? toNum(record.aSkattAmount) : 0,
+          pensionEmployee: record.pensionEmployeeAmount ? toNum(record.pensionEmployeeAmount) : 0,
+          pensionEmployer: record.pensionEmployerAmount ? toNum(record.pensionEmployerAmount) : 0,
+          atp: record.atpAmount ? toNum(record.atpAmount) : 0,
+          bruttoDeduction: record.bruttoDeductionAmount ? toNum(record.bruttoDeductionAmount) : 0,
+          otherDeductions: record.otherDeductions
+            ? (record.otherDeductions as { label: string; amount: number }[]).reduce((s, i) => s + i.amount, 0)
+            : 0,
+        } : null
+
+        return { job, gross, net, deductions }
       })
     )
 
@@ -195,7 +221,10 @@ export async function profileRoutes(fastify: FastifyInstance) {
     const jobIncomeMap = new Map(jobIncomes.map(({ job, gross }) => [job.id, gross]))
     const jobNetIncomeMap = new Map(jobIncomes.map(({ job, net }) => [job.id, net]))
 
-    // Fetch all allocations for active jobs with ACTIVE/FUTURE budget years, including household name
+    // Determine layout mode: 3-column if any job has deduction data
+    const useGranularLayout = jobIncomes.some(({ deductions }) => deductions !== null)
+
+    // Fetch all allocations for active jobs with ACTIVE/FUTURE budget years
     const allocations = await prisma.householdIncomeAllocation.findMany({
       where: {
         jobId: { in: jobIds },
@@ -254,7 +283,6 @@ export async function profileRoutes(fastify: FastifyInstance) {
         const totalExpenses = expenseRows.reduce((s, e) => s + toNum(e.monthlyEquivalent), 0)
         const totalSavings = savingsRows.reduce((s, e) => s + toNum(e.monthlyEquivalent), 0)
 
-        // Compute total household gross income to determine user's proportional share
         const allAllocGross = await Promise.all(
           allAllocations.map(async (alloc) => {
             const { gross } = await getJobMonthlyIncome(alloc.jobId, today)
@@ -273,9 +301,7 @@ export async function profileRoutes(fastify: FastifyInstance) {
       })
     )
 
-    // Accumulate per-job contributions to each aggregate bucket across all households.
-    // For each job's allocation to household H, its fraction of the user's H-bucket is:
-    //   frac = (gross_J * pct_Jh) / userAllocGross_H
+    // Accumulate per-job contributions to each aggregate bucket across all households
     const jobBuckets = new Map<string, { taxes: number; expenses: number; savings: number; surplus: number }>()
     for (const { job } of jobIncomes) {
       jobBuckets.set(job.id, { taxes: 0, expenses: 0, savings: 0, surplus: 0 })
@@ -296,7 +322,6 @@ export async function profileRoutes(fastify: FastifyInstance) {
       }
     }
 
-    // Build d3-sankey nodes and links — 2-column: Jobs → aggregate buckets (no household pass-through)
     const JOB_COLOR_PALETTE = [
       '#f59e0b', '#3b82f6', '#10b981', '#ef4444', '#8b5cf6',
       '#ec4899', '#06b6d4', '#84cc16',
@@ -305,26 +330,93 @@ export async function profileRoutes(fastify: FastifyInstance) {
     const nodes: { id: string; name: string; color?: string }[] = []
     const links: { source: string; target: string; value: number }[] = []
 
-    // Compute aggregate bucket totals to decide which right-side nodes to emit
-    const aggTaxes = householdDetails.reduce((s, h) => s + h.taxes, 0)
     const aggExpenses = householdDetails.reduce((s, h) => s + h.expenses, 0)
     const aggSavings = householdDetails.reduce((s, h) => s + h.savings, 0)
     const aggSurplus = householdDetails.reduce((s, h) => s + h.surplus, 0)
 
-    // Job nodes
+    // Job nodes (shared between both layout modes)
     jobIncomes.forEach(({ job, gross }, i) => {
       if (gross <= 0) return
       nodes.push({ id: `job_${job.id}`, name: job.name, color: JOB_COLOR_PALETTE[i % JOB_COLOR_PALETTE.length] })
     })
 
-    // Right-side aggregate nodes
+    // ── 3-column layout: Jobs → Deduction nodes + Net Pay → Expenses/Savings/Surplus ──
+    if (useGranularLayout) {
+      // Aggregate deduction totals across all jobs
+      const aggAmBidrag = jobIncomes.reduce((s, { deductions }) => s + (deductions?.amBidrag ?? 0), 0)
+      const aggASkat = jobIncomes.reduce((s, { deductions }) => s + (deductions?.aSkat ?? 0), 0)
+      const aggPensionEmployee = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployee ?? 0), 0)
+      const aggPensionEmployer = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployer ?? 0), 0)
+      const aggAtp = jobIncomes.reduce((s, { deductions }) => s + (deductions?.atp ?? 0), 0)
+      const aggBrutto = jobIncomes.reduce((s, { deductions }) => s + (deductions?.bruttoDeduction ?? 0), 0)
+      const aggOther = jobIncomes.reduce((s, { deductions }) => s + (deductions?.otherDeductions ?? 0), 0)
+      const totalNetPay = jobIncomes.reduce((s, { net }) => s + net, 0)
+
+      // Middle column: deduction nodes
+      if (aggBrutto > 0) nodes.push({ id: 'brutto_benefits', name: 'Brutto Benefits' })
+      if (aggAmBidrag > 0) nodes.push({ id: 'am_bidrag', name: 'AM-bidrag' })
+      if (aggASkat > 0) nodes.push({ id: 'a_skat', name: 'A-skat' })
+      if (aggPensionEmployee > 0) nodes.push({ id: 'pension_employee', name: 'Pension (Employee)' })
+      if (aggAtp > 0) nodes.push({ id: 'atp', name: 'ATP' })
+      if (aggOther > 0) nodes.push({ id: 'other_deductions', name: 'Other Deductions' })
+      nodes.push({ id: 'net_pay', name: 'Net Pay' })
+
+      // Right column
+      if (aggExpenses > 0) nodes.push({ id: 'expenses', name: 'Expenses' })
+      if (aggSavings > 0) nodes.push({ id: 'savings', name: 'Savings' })
+      if (aggSurplus > 0) nodes.push({ id: 'surplus', name: 'Surplus' })
+      if (unallocatedAmount > 0) nodes.push({ id: 'unallocated', name: 'Unallocated' })
+
+      // Links: job → deduction nodes + net_pay
+      for (const { job, gross, net, deductions } of jobIncomes) {
+        if (gross <= 0) continue
+        const jobId = `job_${job.id}`
+
+        if (deductions) {
+          if (deductions.bruttoDeduction > 0) links.push({ source: jobId, target: 'brutto_benefits', value: deductions.bruttoDeduction })
+          if (deductions.amBidrag > 0) links.push({ source: jobId, target: 'am_bidrag', value: deductions.amBidrag })
+          if (deductions.aSkat > 0) links.push({ source: jobId, target: 'a_skat', value: deductions.aSkat })
+          if (deductions.pensionEmployee > 0) links.push({ source: jobId, target: 'pension_employee', value: deductions.pensionEmployee })
+          if (deductions.atp > 0) links.push({ source: jobId, target: 'atp', value: deductions.atp })
+          if (deductions.otherDeductions > 0) links.push({ source: jobId, target: 'other_deductions', value: deductions.otherDeductions })
+        } else {
+          // Job without deduction data — its taxes component flows to a_skat as fallback
+          const bucket = jobBuckets.get(job.id)!
+          if (bucket.taxes > 0) links.push({ source: jobId, target: 'a_skat', value: bucket.taxes })
+        }
+        if (net > 0) links.push({ source: jobId, target: 'net_pay', value: net })
+      }
+
+      // Links: net_pay → right-side nodes
+      // Proportions from household budget, applied to total net pay
+      if (totalNetPay > 0) {
+        if (aggExpenses > 0) links.push({ source: 'net_pay', target: 'expenses', value: aggExpenses })
+        if (aggSavings > 0) links.push({ source: 'net_pay', target: 'savings', value: aggSavings })
+        if (aggSurplus > 0) links.push({ source: 'net_pay', target: 'surplus', value: aggSurplus })
+        // Unallocated: scale the gross unallocated proportionally to net
+        const unallocatedNet = unallocatedAmount * (totalNetPay / totalIncome)
+        if (unallocatedNet > 0) links.push({ source: 'net_pay', target: 'unallocated', value: unallocatedNet })
+      }
+
+      const totalEmployerPension = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployer ?? 0), 0)
+
+      return reply.send({
+        totalIncome: totalIncome.toFixed(2),
+        ...(totalEmployerPension > 0 && { employerPensionMonthly: totalEmployerPension.toFixed(2) }),
+        nodes,
+        links,
+      })
+    }
+
+    // ── 2-column layout (fallback): Jobs → Taxes + Expenses + Savings + Surplus ──
+    const aggTaxes = householdDetails.reduce((s, h) => s + h.taxes, 0)
+
     if (aggTaxes > 0) nodes.push({ id: 'taxes', name: 'Taxes' })
     if (aggExpenses > 0) nodes.push({ id: 'expenses', name: 'Expenses' })
     if (aggSavings > 0) nodes.push({ id: 'savings', name: 'Savings' })
     if (aggSurplus > 0) nodes.push({ id: 'surplus', name: 'Surplus' })
     if (unallocatedAmount > 0) nodes.push({ id: 'unallocated', name: 'Unallocated' })
 
-    // Links: job → each right-side bucket
     for (const { job, gross } of jobIncomes) {
       if (gross <= 0) continue
       const bucket = jobBuckets.get(job.id)!
@@ -333,7 +425,6 @@ export async function profileRoutes(fastify: FastifyInstance) {
       if (bucket.savings > 0) links.push({ source: `job_${job.id}`, target: 'savings', value: bucket.savings })
       if (bucket.surplus > 0) links.push({ source: `job_${job.id}`, target: 'surplus', value: bucket.surplus })
 
-      // Unallocated portion of this job
       const jobAllocated = allocations
         .filter((a) => a.jobId === job.id)
         .reduce((s, a) => s + gross * parseFloat(a.allocationPct.toString()) / 100, 0)

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -200,19 +200,26 @@ export async function profileRoutes(fastify: FastifyInstance) {
         })
 
         const hasDeductions = record?.deductionsSource != null
-        const deductions = hasDeductions && record ? {
-          amBidrag: record.amBidragAmount ? toNum(record.amBidragAmount) : 0,
-          aSkat: record.aSkattAmount ? toNum(record.aSkattAmount) : 0,
-          pensionEmployee: record.pensionEmployeeAmount ? toNum(record.pensionEmployeeAmount) : 0,
-          pensionEmployer: record.pensionEmployerAmount ? toNum(record.pensionEmployerAmount) : 0,
-          atp: record.atpAmount ? toNum(record.atpAmount) : 0,
-          bruttoDeduction: record.bruttoDeductionAmount ? toNum(record.bruttoDeductionAmount) : 0,
-          otherDeductions: record.otherDeductions
-            ? (record.otherDeductions as { label: string; amount: number }[]).reduce((s, i) => s + i.amount, 0)
-            : 0,
-        } : null
+        const deductions = hasDeductions && record ? (() => {
+          const lines = (record.payslipLines ?? []) as { amount: number; sankeyGroup?: string }[]
+          const byGroup = new Map<string, number>()
+          for (const line of lines) {
+            if (line.sankeyGroup) {
+              byGroup.set(line.sankeyGroup, (byGroup.get(line.sankeyGroup) ?? 0) + line.amount)
+            }
+          }
+          return {
+            amBidrag: byGroup.get('am_bidrag') ?? 0,
+            aSkat: byGroup.get('a_skat') ?? 0,
+            pensionEmployee: byGroup.get('pension_employee') ?? 0,
+            atp: byGroup.get('atp') ?? 0,
+            bruttoDeduction: byGroup.get('brutto_benefits') ?? 0,
+            otherDeductions: byGroup.get('other_deductions') ?? 0,
+          }
+        })() : null
+        const pensionEmployer = record?.pensionEmployerMonthly ? toNum(record.pensionEmployerMonthly) : 0
 
-        return { job, gross, net, deductions }
+        return { job, gross, net, deductions, pensionEmployer }
       })
     )
 
@@ -346,7 +353,7 @@ export async function profileRoutes(fastify: FastifyInstance) {
       const aggAmBidrag = jobIncomes.reduce((s, { deductions }) => s + (deductions?.amBidrag ?? 0), 0)
       const aggASkat = jobIncomes.reduce((s, { deductions }) => s + (deductions?.aSkat ?? 0), 0)
       const aggPensionEmployee = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployee ?? 0), 0)
-      const aggPensionEmployer = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployer ?? 0), 0)
+      const aggPensionEmployer = jobIncomes.reduce((s, { pensionEmployer }) => s + pensionEmployer, 0)
       const aggAtp = jobIncomes.reduce((s, { deductions }) => s + (deductions?.atp ?? 0), 0)
       const aggBrutto = jobIncomes.reduce((s, { deductions }) => s + (deductions?.bruttoDeduction ?? 0), 0)
       const aggOther = jobIncomes.reduce((s, { deductions }) => s + (deductions?.otherDeductions ?? 0), 0)
@@ -398,7 +405,7 @@ export async function profileRoutes(fastify: FastifyInstance) {
         if (unallocatedNet > 0) links.push({ source: 'net_pay', target: 'unallocated', value: unallocatedNet })
       }
 
-      const totalEmployerPension = jobIncomes.reduce((s, { deductions }) => s + (deductions?.pensionEmployer ?? 0), 0)
+      const totalEmployerPension = jobIncomes.reduce((s, { pensionEmployer }) => s + pensionEmployer, 0)
 
       return reply.send({
         totalIncome: totalIncome.toFixed(2),

--- a/apps/web/src/components/SankeyChart.tsx
+++ b/apps/web/src/components/SankeyChart.tsx
@@ -34,9 +34,20 @@ const FALLBACK_COLORS = [
   '#ec4899', '#06b6d4', '#84cc16',
 ]
 
+// Fixed colors for well-known deduction node IDs
+const NODE_ID_COLORS: Record<string, string> = {
+  brutto_benefits: '#8b5cf6',
+  am_bidrag: '#ef4444',
+  a_skat: '#f97316',
+  pension_employee: '#eab308',
+  atp: '#6b7280',
+  other_deductions: '#9ca3af',
+  net_pay: '#10b981',
+}
+
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export function SankeyChart({ data, currency = '' }: { data: { nodes: SankeyNodeDef[]; links: SankeyLinkDef[] }; currency?: string }) {
+export function SankeyChart({ data, currency = '', height: heightProp }: { data: { nodes: SankeyNodeDef[]; links: SankeyLinkDef[] }; currency?: string; height?: number }) {
   function fmt(v: number | string) {
     const n = Number(v).toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     return currency ? `${n} ${currency}` : n
@@ -51,7 +62,7 @@ export function SankeyChart({ data, currency = '' }: { data: { nodes: SankeyNode
 
   const compute = useCallback(() => {
     const width = containerRef.current?.clientWidth ?? 800
-    const height = 400
+    const height = heightProp ?? 400
     const nodeIndexMap = new Map(data.nodes.map((n, i) => [n.id, i]))
     const sankeyNodes: SankeyExtNode[] = data.nodes.map((n) => ({ ...n }))
     const sankeyLinks = data.links
@@ -96,9 +107,9 @@ export function SankeyChart({ data, currency = '' }: { data: { nodes: SankeyNode
     return () => observer.disconnect()
   }, [compute])
 
-  const colorMap = new Map(data.nodes.map((n, i) => [n.id, n.color ?? FALLBACK_COLORS[i % FALLBACK_COLORS.length]]))
+  const colorMap = new Map(data.nodes.map((n, i) => [n.id, n.color ?? NODE_ID_COLORS[n.id] ?? FALLBACK_COLORS[i % FALLBACK_COLORS.length]]))
 
-  const { nodes, links, width, height } = svgContent ?? { nodes: [], links: [], width: 0, height: 400 }
+  const { nodes, links, width, height } = svgContent ?? { nodes: [], links: [], width: 0, height: heightProp ?? 400 }
   const linkPath = sankeyLinkHorizontal()
 
   return (

--- a/apps/web/src/pages/IncomePage.tsx
+++ b/apps/web/src/pages/IncomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useState, useMemo, type FormEvent } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
@@ -27,6 +27,13 @@ interface SalaryRecord {
   effectiveFrom: string
   currencyCode: string | null
   rateUsed: string | null
+  amBidragAmount: string | null
+  aSkattAmount: string | null
+  pensionEmployeeAmount: string | null
+  pensionEmployerAmount: string | null
+  atpAmount: string | null
+  bruttoDeductionAmount: string | null
+  deductionsSource: string | null
   createdAt: string
 }
 
@@ -38,6 +45,27 @@ interface MonthlyOverride {
   grossAmount: string
   netAmount: string
   note: string | null
+  amBidragAmount: string | null
+  aSkattAmount: string | null
+  pensionEmployeeAmount: string | null
+  pensionEmployerAmount: string | null
+  atpAmount: string | null
+  bruttoDeductionAmount: string | null
+  deductionsSource: string | null
+  createdAt: string
+}
+
+interface TaxCardSettings {
+  id: string
+  jobId: string
+  effectiveFrom: string
+  traekprocent: string
+  personfradragMonthly: string
+  municipality: string | null
+  pensionEmployeePct: string | null
+  pensionEmployerPct: string | null
+  atpAmount: string | null
+  bruttoItems: { label: string; monthlyAmount: number }[] | null
   createdAt: string
 }
 
@@ -76,6 +104,7 @@ interface Job {
   id: string
   name: string
   employer: string | null
+  country: string
   startDate: string
   endDate: string | null
   isActive: boolean
@@ -116,15 +145,320 @@ type Granularity = 'monthly' | 'quarterly' | 'yearly'
 
 // ── Sub-forms ─────────────────────────────────────────────────────────────────
 
-interface JobForm { name: string; employer: string; startDate: string; endDate: string }
+interface JobForm { name: string; employer: string; country: string; startDate: string; endDate: string }
 interface SalaryForm { grossAmount: string; netAmount: string; effectiveFrom: string; currencyCode: string }
 interface OverrideForm { year: string; month: string; grossAmount: string; netAmount: string; note: string }
 interface BonusForm { label: string; grossAmount: string; netAmount: string; paymentDate: string; includeInBudget: boolean; budgetMode: BudgetMode | ''; currencyCode: string }
 
-const emptyJob: JobForm = { name: '', employer: '', startDate: new Date().toISOString().slice(0, 10), endDate: '' }
+interface TaxCardForm {
+  effectiveFrom: string
+  traekprocent: string
+  personfradragMonthly: string
+  municipality: string
+  pensionEmployeePct: string
+  pensionEmployerPct: string
+  atpAmount: string
+  bruttoItems: { label: string; monthlyAmount: string }[]
+}
+
+interface DeductionOverrides {
+  amBidragAmount: string
+  aSkattAmount: string
+  pensionEmployeeAmount: string
+  atpAmount: string
+}
+
+const emptyJob: JobForm = { name: '', employer: '', country: 'DK', startDate: new Date().toISOString().slice(0, 10), endDate: '' }
 const emptySalary = (baseCurrency: string): SalaryForm => ({ grossAmount: '', netAmount: '', effectiveFrom: new Date().toISOString().slice(0, 10), currencyCode: baseCurrency })
 const emptyOverride: OverrideForm = { year: String(new Date().getFullYear()), month: String(new Date().getMonth() + 1), grossAmount: '', netAmount: '', note: '' }
 const emptyBonus = (baseCurrency: string): BonusForm => ({ label: '', grossAmount: '', netAmount: '', paymentDate: new Date().toISOString().slice(0, 10), includeInBudget: true, budgetMode: 'ONE_OFF', currencyCode: baseCurrency })
+const emptyTaxCard = (): TaxCardForm => ({ effectiveFrom: new Date().toISOString().slice(0, 10), traekprocent: '', personfradragMonthly: '3875', municipality: '', pensionEmployeePct: '', pensionEmployerPct: '', atpAmount: '', bruttoItems: [] })
+const emptyDeductionOverrides = (): DeductionOverrides => ({ amBidragAmount: '', aSkattAmount: '', pensionEmployeeAmount: '', atpAmount: '' })
+
+// ── Inline DK tax calculation (mirrors packages/shared/src/index.ts) ──────────
+
+const TOP_SKAT_THRESHOLD = 49_075
+const TOP_SKAT_RATE = 0.15
+const AM_BIDRAG_RATE = 0.08
+const DEFAULT_ATP = 99
+
+function r2(n: number) { return Math.round(n * 100) / 100 }
+
+interface LiveDeductions {
+  amBidrag: number; aSkat: number; topSkat: number; atp: number
+  pensionEmployee: number; pensionEmployer: number; bruttoTotal: number; net: number
+}
+
+function calcDanishDeductions(
+  gross: number,
+  settings: { traekprocent: number; personfradragMonthly: number; pensionEmployeePct?: number | null; pensionEmployerPct?: number | null; atpAmount?: number | null; bruttoItems?: { label: string; monthlyAmount: number }[] | null }
+): LiveDeductions {
+  const items = settings.bruttoItems ?? []
+  const bruttoTotal = r2(items.reduce((s, i) => s + i.monthlyAmount, 0))
+  const taxableGross = gross - bruttoTotal
+  const amBidrag = r2(taxableGross * AM_BIDRAG_RATE)
+  const aIndkomst = taxableGross - amBidrag
+  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
+  const bottomTax = r2(taxableBase * settings.traekprocent / 100)
+  const topSkat = r2(Math.max(0, aIndkomst - TOP_SKAT_THRESHOLD) * TOP_SKAT_RATE)
+  const aSkat = bottomTax + topSkat
+  const atp = r2(settings.atpAmount ?? DEFAULT_ATP)
+  const pensionEmployee = settings.pensionEmployeePct ? r2(gross * settings.pensionEmployeePct / 100) : 0
+  const pensionEmployer = settings.pensionEmployerPct ? r2(gross * settings.pensionEmployerPct / 100) : 0
+  const net = r2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
+  return { amBidrag, aSkat, topSkat, atp, pensionEmployee, pensionEmployer, bruttoTotal, net }
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function fmt2(n: number, cur: string) {
+  return `${n.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${cur}`
+}
+
+interface DeductionPanelProps {
+  gross: number
+  liveCalc: LiveDeductions | null
+  overrides: DeductionOverrides
+  onOverrideChange: (field: keyof DeductionOverrides, val: string) => void
+  hasTaxCard: boolean
+  baseCurrency: string
+}
+
+function DeductionPanel({ gross, liveCalc, overrides, onOverrideChange, hasTaxCard, baseCurrency }: DeductionPanelProps) {
+  const [editingField, setEditingField] = useState<keyof DeductionOverrides | null>(null)
+
+  if (!hasTaxCard && !liveCalc) {
+    return (
+      <div className="rounded-lg bg-gray-800/50 border border-gray-700 p-4 text-sm text-gray-400">
+        <p>Add tax card settings to enable auto-calculation of deductions.</p>
+        <p className="mt-1 text-xs text-gray-500">You can still save a salary record; deductions will be stored as-is.</p>
+      </div>
+    )
+  }
+
+  if (!liveCalc || !gross) {
+    return (
+      <div className="rounded-lg bg-gray-800/50 border border-gray-700 p-4 text-sm text-gray-400">
+        Enter a gross amount to see the deduction breakdown.
+      </div>
+    )
+  }
+
+  const hasManualOverride = Object.values(overrides).some((v) => v !== '')
+  const displayNet = hasManualOverride
+    ? r2(gross - liveCalc.bruttoTotal - (parseFloat(overrides.amBidragAmount) || liveCalc.amBidrag) - (parseFloat(overrides.aSkattAmount) || liveCalc.aSkat) - (parseFloat(overrides.pensionEmployeeAmount) || liveCalc.pensionEmployee) - (parseFloat(overrides.atpAmount) || liveCalc.atp))
+    : liveCalc.net
+
+  function DeductionRow({ label, field, calcValue }: { label: string; field: keyof DeductionOverrides; calcValue: number }) {
+    const isManual = overrides[field] !== ''
+    const displayVal = isManual ? (parseFloat(overrides[field]) || 0) : calcValue
+    return (
+      <div className="flex items-center justify-between py-1.5 border-b border-gray-700/50 last:border-0">
+        <div className="flex items-center gap-2">
+          <span className="text-gray-300 text-sm">{label}</span>
+          <span className={`text-xs px-1.5 py-0.5 rounded ${isManual ? 'bg-amber-900/50 text-amber-400 border border-amber-700' : 'bg-gray-700 text-gray-400'}`}>
+            {isManual ? 'manual' : 'calc'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {editingField === field ? (
+            <input
+              type="number" step="0.01" autoFocus
+              defaultValue={isManual ? overrides[field] : calcValue.toFixed(2)}
+              onBlur={(e) => { onOverrideChange(field, e.target.value); setEditingField(null) }}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); (e.target as HTMLInputElement).blur() } if (e.key === 'Escape') { onOverrideChange(field, ''); setEditingField(null) } }}
+              className="w-28 bg-gray-700 border border-amber-500 rounded px-2 py-0.5 text-white text-sm text-right focus:outline-none"
+            />
+          ) : (
+            <>
+              <span className="text-sm tabular-nums text-red-400">−{fmt2(displayVal, baseCurrency)}</span>
+              <button type="button" onClick={() => setEditingField(field)} className="text-gray-500 hover:text-gray-300 text-xs" title="Override">✏</button>
+              {isManual && (
+                <button type="button" onClick={() => onOverrideChange(field, '')} className="text-gray-600 hover:text-gray-400 text-xs" title="Reset to calculated">↺</button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg bg-gray-800/50 border border-gray-700 p-4 space-y-1">
+      {liveCalc.bruttoTotal > 0 && (
+        <div className="flex justify-between py-1.5 border-b border-gray-700/50 text-sm">
+          <span className="text-purple-300">Brutto benefits</span>
+          <span className="tabular-nums text-purple-400">−{fmt2(liveCalc.bruttoTotal, baseCurrency)}</span>
+        </div>
+      )}
+      {liveCalc.bruttoTotal > 0 && (
+        <div className="flex justify-between py-1 text-xs text-gray-500 border-b border-gray-700/50">
+          <span>Taxable gross</span>
+          <span className="tabular-nums">{fmt2(gross - liveCalc.bruttoTotal, baseCurrency)}</span>
+        </div>
+      )}
+      <DeductionRow label="AM-bidrag (8%)" field="amBidragAmount" calcValue={liveCalc.amBidrag} />
+      <DeductionRow label={`A-skat${liveCalc.topSkat > 0 ? ` (incl. top-skat ${fmt2(liveCalc.topSkat, baseCurrency)})` : ''}`} field="aSkattAmount" calcValue={liveCalc.aSkat} />
+      {liveCalc.pensionEmployee > 0 && (
+        <DeductionRow label="Employee pension" field="pensionEmployeeAmount" calcValue={liveCalc.pensionEmployee} />
+      )}
+      <DeductionRow label="ATP" field="atpAmount" calcValue={liveCalc.atp} />
+      <div className="flex justify-between pt-2 border-t border-gray-600 font-semibold text-sm mt-1">
+        <span className="text-white">Net pay</span>
+        <span className="tabular-nums text-amber-400">{fmt2(displayNet, baseCurrency)}</span>
+      </div>
+      {liveCalc.pensionEmployer > 0 && (
+        <div className="flex justify-between pt-1 text-xs text-gray-500">
+          <span>Employer pension (not deducted)</span>
+          <span className="tabular-nums">{fmt2(liveCalc.pensionEmployer, baseCurrency)}</span>
+        </div>
+      )}
+      {hasManualOverride && (
+        <button type="button" onClick={() => { onOverrideChange('amBidragAmount', ''); onOverrideChange('aSkattAmount', ''); onOverrideChange('pensionEmployeeAmount', ''); onOverrideChange('atpAmount', '') }}
+          className="text-xs text-gray-500 hover:text-gray-300 transition-colors mt-1">Reset all to calculated</button>
+      )}
+    </div>
+  )
+}
+
+interface TaxCardSectionProps {
+  jobId: string
+  cards: TaxCardSettings[]
+  isExpanded: boolean
+  onToggle: () => void
+  showForm: boolean
+  onShowForm: () => void
+  onHideForm: () => void
+  form: TaxCardForm
+  onFormChange: (f: TaxCardForm) => void
+  onSubmit: (e: FormEvent) => void
+  isPending: boolean
+  error: string
+  fmt: (v: number | string) => string
+}
+
+function TaxCardSection({ jobId: _jobId, cards, isExpanded, onToggle, showForm, onShowForm, onHideForm, form, onFormChange, onSubmit, isPending, error, fmt }: TaxCardSectionProps) {
+  const activeCard = cards[0] ?? null
+  return (
+    <div className="border-t border-gray-800 pt-4 mt-2">
+      <button type="button" onClick={onToggle}
+        className="flex items-center gap-2 text-xs font-medium text-gray-400 hover:text-white transition-colors mb-2">
+        <span>Tax card settings</span>
+        {activeCard && <span className="text-green-400">● Active</span>}
+        <span>{isExpanded ? '▲' : '▼'}</span>
+      </button>
+      {isExpanded && (
+        <div className="space-y-3">
+          {cards.length > 0 && (
+            <div className="space-y-2">
+              {cards.map((card, i) => (
+                <div key={card.id} className="bg-gray-800 rounded-lg p-3 text-sm">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-gray-300 font-medium">
+                      {new Date(card.effectiveFrom).toLocaleDateString('en', { year: 'numeric', month: 'short', day: 'numeric' })}
+                    </span>
+                    {i === 0 && <span className="text-xs bg-green-900/50 text-green-400 border border-green-700 px-1.5 py-0.5 rounded">Active</span>}
+                  </div>
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs text-gray-400">
+                    <span>Trækprocent: <span className="text-white">{parseFloat(card.traekprocent).toFixed(2)}%</span></span>
+                    <span>Personfradrag: <span className="text-white">{fmt(card.personfradragMonthly)}</span></span>
+                    {card.pensionEmployeePct && <span>Pension emp.: <span className="text-white">{parseFloat(card.pensionEmployeePct).toFixed(2)}%</span></span>}
+                    {card.pensionEmployerPct && <span>Pension er.: <span className="text-white">{parseFloat(card.pensionEmployerPct).toFixed(2)}%</span></span>}
+                    {card.municipality && <span>Municipality: <span className="text-white">{card.municipality}</span></span>}
+                  </div>
+                  {card.bruttoItems && card.bruttoItems.length > 0 && (
+                    <div className="mt-1.5 text-xs text-gray-500">
+                      Brutto: {card.bruttoItems.map((b) => `${b.label} (${fmt(b.monthlyAmount)})`).join(', ')}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {!showForm ? (
+            <button type="button" onClick={onShowForm}
+              className="text-xs text-amber-400 hover:text-amber-300 border border-amber-700 px-3 py-1.5 rounded-lg transition-colors">
+              + Add tax card record
+            </button>
+          ) : (
+            <form onSubmit={onSubmit} className="bg-gray-800 rounded-lg p-4 space-y-3">
+              <p className="text-xs font-medium text-gray-300 mb-2">New tax card settings</p>
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">Effective from</label>
+                  <input type="date" value={form.effectiveFrom} onChange={(e) => onFormChange({ ...form, effectiveFrom: e.target.value })}
+                    required className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">Trækprocent (%)</label>
+                  <input type="number" value={form.traekprocent} onChange={(e) => onFormChange({ ...form, traekprocent: e.target.value })}
+                    required min="0" max="100" step="0.01" placeholder="38.00"
+                    className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">Personfradrag / month</label>
+                  <input type="number" value={form.personfradragMonthly} onChange={(e) => onFormChange({ ...form, personfradragMonthly: e.target.value })}
+                    required min="0" step="0.01" placeholder="3875"
+                    className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">Pension employee %</label>
+                  <input type="number" value={form.pensionEmployeePct} onChange={(e) => onFormChange({ ...form, pensionEmployeePct: e.target.value })}
+                    min="0" max="100" step="0.01" placeholder="4.00"
+                    className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">Pension employer %</label>
+                  <input type="number" value={form.pensionEmployerPct} onChange={(e) => onFormChange({ ...form, pensionEmployerPct: e.target.value })}
+                    min="0" max="100" step="0.01" placeholder="8.00"
+                    className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-400 mb-1">ATP override (DKK)</label>
+                  <input type="number" value={form.atpAmount} onChange={(e) => onFormChange({ ...form, atpAmount: e.target.value })}
+                    min="0" step="0.01" placeholder="99 (default)"
+                    className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                </div>
+              </div>
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">Municipality <span className="text-gray-600">(optional)</span></label>
+                <input type="text" value={form.municipality} onChange={(e) => onFormChange({ ...form, municipality: e.target.value })}
+                  placeholder="e.g. Copenhagen"
+                  className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+              </div>
+              {/* Bruttolønsordning */}
+              <div>
+                <label className="block text-xs text-gray-400 mb-1">Bruttolønsordning items</label>
+                {form.bruttoItems.map((item, idx) => (
+                  <div key={idx} className="flex gap-2 mb-2">
+                    <input type="text" value={item.label} onChange={(e) => { const items = [...form.bruttoItems]; items[idx] = { ...items[idx], label: e.target.value }; onFormChange({ ...form, bruttoItems: items }) }}
+                      placeholder="Label (e.g. Phone)" className="flex-1 bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                    <input type="number" value={item.monthlyAmount} onChange={(e) => { const items = [...form.bruttoItems]; items[idx] = { ...items[idx], monthlyAmount: e.target.value }; onFormChange({ ...form, bruttoItems: items }) }}
+                      placeholder="Amount" min="0" step="0.01" className="w-28 bg-gray-700 border border-gray-600 rounded px-2 py-1.5 text-white text-sm focus:outline-none focus:ring-1 focus:ring-amber-400" />
+                    <button type="button" onClick={() => onFormChange({ ...form, bruttoItems: form.bruttoItems.filter((_, i) => i !== idx) })}
+                      className="text-red-500 hover:text-red-400 text-sm px-1">×</button>
+                  </div>
+                ))}
+                <button type="button" onClick={() => onFormChange({ ...form, bruttoItems: [...form.bruttoItems, { label: '', monthlyAmount: '' }] })}
+                  className="text-xs text-gray-400 hover:text-white border border-gray-600 px-2 py-1 rounded transition-colors">+ Add item</button>
+              </div>
+              {error && <div className="bg-red-950 border border-red-800 text-red-300 px-3 py-2 rounded text-xs">{error}</div>}
+              <div className="flex gap-2">
+                <button type="submit" disabled={isPending}
+                  className="bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold text-xs px-3 py-1.5 rounded transition-colors">
+                  {isPending ? 'Saving…' : 'Save'}
+                </button>
+                <button type="button" onClick={onHideForm} className="text-xs text-gray-500 hover:text-gray-300 transition-colors">Cancel</button>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -166,6 +500,17 @@ export function IncomePage() {
   const [pendingAllocations, setPendingAllocations] = useState<Record<string, string>>({})
   const [allocError, setAllocError] = useState('')
   const [allocationsDirty, setAllocationsDirty] = useState(false)
+
+  // Tax card settings
+  const [taxCardJobId, setTaxCardJobId] = useState<string | null>(null)
+  const [showTaxCardForm, setShowTaxCardForm] = useState(false)
+  const [taxCardForm, setTaxCardForm] = useState<TaxCardForm>(emptyTaxCard())
+  const [taxCardError, setTaxCardError] = useState('')
+
+  // Deduction overrides (salary + override forms)
+  const [salaryDeductionOverrides, setSalaryDeductionOverrides] = useState<DeductionOverrides>(emptyDeductionOverrides())
+  const [overrideDeductionOpen, setOverrideDeductionOpen] = useState(false)
+  const [overrideDeductionOverrides, setOverrideDeductionOverrides] = useState<DeductionOverrides>(emptyDeductionOverrides())
 
   // Confirmation dialogs
   const [confirmCloseJob, setConfirmCloseJob] = useState<Job | null>(null)
@@ -248,6 +593,21 @@ export function IncomePage() {
     enabled: activeTab === 'bonuses' && jobs.length > 0,
   })
 
+  const { data: taxCards = {} } = useQuery<Record<string, TaxCardSettings[]>>({
+    queryKey: ['taxcards', jobs.map((j) => j.id).join(',')],
+    queryFn: async () => {
+      const dkJobs = jobs.filter((j) => j.country === 'DK')
+      const results = await Promise.all(
+        dkJobs.map(async (j) => {
+          const res = await api.get<TaxCardSettings[]>(`/jobs/${j.id}/taxcard`)
+          return [j.id, res.data] as [string, TaxCardSettings[]]
+        })
+      )
+      return Object.fromEntries(results)
+    },
+    enabled: jobs.length > 0,
+  })
+
   const { data: historyData } = useQuery<{ buckets: HistoryBucket[] }>({
     queryKey: ['income-history', targetUserId, histFrom, histTo, granularity],
     queryFn: async () =>
@@ -260,7 +620,7 @@ export function IncomePage() {
   const createJobMutation = useMutation({
     mutationFn: (data: JobForm) =>
       api.post(`/users/${targetUserId}/jobs`, {
-        name: data.name, employer: data.employer || undefined,
+        name: data.name, employer: data.employer || undefined, country: data.country,
         startDate: data.startDate, endDate: data.endDate || undefined,
       }),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['jobs'] }); setShowAddJob(false); setJobForm(emptyJob); setJobFormError(''); toast.success('Job saved') },
@@ -270,7 +630,7 @@ export function IncomePage() {
   const updateJobMutation = useMutation({
     mutationFn: (data: JobForm) =>
       api.put(`/users/${targetUserId}/jobs/${editingJob!.id}`, {
-        name: data.name, employer: data.employer || undefined,
+        name: data.name, employer: data.employer || undefined, country: data.country,
         startDate: data.startDate, endDate: data.endDate || undefined,
       }),
     onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['jobs'] }); setEditingJob(null); setJobForm(emptyJob); setJobFormError(''); toast.success('Job saved') },
@@ -283,30 +643,56 @@ export function IncomePage() {
   })
 
   const addSalaryMutation = useMutation({
-    mutationFn: (data: SalaryForm) =>
-      api.post(`/jobs/${salaryJobId}/salary`, {
-        grossAmount: parseFloat(data.grossAmount), netAmount: parseFloat(data.netAmount), effectiveFrom: data.effectiveFrom,
-        ...(data.currencyCode && data.currencyCode !== baseCurrency ? { currencyCode: data.currencyCode } : {}),
-      }),
+    mutationFn: ({ form, deductionOverrides, liveCalc }: { form: SalaryForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
+      const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
+      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
+        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
+        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
+        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
+        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
+        deductionsSource: 'MANUAL',
+      } : {}
+      const net = liveCalc
+        ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
+        : parseFloat(form.netAmount)
+      return api.post(`/jobs/${salaryJobId}/salary`, {
+        grossAmount: parseFloat(form.grossAmount), netAmount: net, effectiveFrom: form.effectiveFrom,
+        ...(form.currencyCode && form.currencyCode !== baseCurrency ? { currencyCode: form.currencyCode } : {}),
+        ...deductionPayload,
+      })
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['salary', salaryJobId] })
       queryClient.invalidateQueries({ queryKey: ['jobs'] })
-      setSalaryForm(emptySalary(baseCurrency)); setSalaryError('')
+      setSalaryForm(emptySalary(baseCurrency)); setSalaryDeductionOverrides(emptyDeductionOverrides()); setSalaryError('')
       toast.success('Salary record added')
     },
     onError: (err) => { if (axios.isAxiosError(err)) setSalaryError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
   })
 
   const updateSalaryMutation = useMutation({
-    mutationFn: (data: SalaryForm) =>
-      api.put(`/jobs/${salaryJobId}/salary/${editingSalary!.id}`, {
-        grossAmount: parseFloat(data.grossAmount), netAmount: parseFloat(data.netAmount), effectiveFrom: data.effectiveFrom,
-        ...(data.currencyCode && data.currencyCode !== baseCurrency ? { currencyCode: data.currencyCode } : {}),
-      }),
+    mutationFn: ({ form, deductionOverrides, liveCalc }: { form: SalaryForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
+      const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
+      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
+        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
+        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
+        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
+        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
+        deductionsSource: 'MANUAL',
+      } : {}
+      const net = liveCalc
+        ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
+        : parseFloat(form.netAmount)
+      return api.put(`/jobs/${salaryJobId}/salary/${editingSalary!.id}`, {
+        grossAmount: parseFloat(form.grossAmount), netAmount: net, effectiveFrom: form.effectiveFrom,
+        ...(form.currencyCode && form.currencyCode !== baseCurrency ? { currencyCode: form.currencyCode } : {}),
+        ...deductionPayload,
+      })
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['salary', salaryJobId] })
       queryClient.invalidateQueries({ queryKey: ['jobs'] })
-      setEditingSalary(null); setSalaryForm(emptySalary(baseCurrency)); setSalaryError('')
+      setEditingSalary(null); setSalaryForm(emptySalary(baseCurrency)); setSalaryDeductionOverrides(emptyDeductionOverrides()); setSalaryError('')
       toast.success('Salary record updated')
     },
     onError: (err) => { if (axios.isAxiosError(err)) setSalaryError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
@@ -322,19 +708,52 @@ export function IncomePage() {
   })
 
   const upsertOverrideMutation = useMutation({
-    mutationFn: (data: OverrideForm) =>
-      api.post(`/jobs/${overrideJobId}/overrides`, {
-        year: parseInt(data.year), month: parseInt(data.month),
-        grossAmount: parseFloat(data.grossAmount), netAmount: parseFloat(data.netAmount),
-        note: data.note || undefined,
-      }),
+    mutationFn: ({ form, deductionOverrides, liveCalc }: { form: OverrideForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
+      const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
+      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
+        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
+        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
+        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
+        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
+        deductionsSource: 'MANUAL',
+      } : {}
+      const net = liveCalc
+        ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
+        : parseFloat(form.netAmount)
+      return api.post(`/jobs/${overrideJobId}/overrides`, {
+        year: parseInt(form.year), month: parseInt(form.month),
+        grossAmount: parseFloat(form.grossAmount), netAmount: net,
+        note: form.note || undefined,
+        ...deductionPayload,
+      })
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['overrides', overrideJobId] })
       queryClient.invalidateQueries({ queryKey: ['all-overrides'] })
-      setOverrideForm(emptyOverride); setOverrideError('')
+      setOverrideForm(emptyOverride); setOverrideDeductionOverrides(emptyDeductionOverrides()); setOverrideDeductionOpen(false); setOverrideError('')
       toast.success('Monthly override saved')
     },
     onError: (err) => { if (axios.isAxiosError(err)) setOverrideError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
+  })
+
+  const createTaxCardMutation = useMutation({
+    mutationFn: (data: TaxCardForm) =>
+      api.post(`/jobs/${taxCardJobId}/taxcard`, {
+        effectiveFrom: data.effectiveFrom,
+        traekprocent: parseFloat(data.traekprocent),
+        personfradragMonthly: parseFloat(data.personfradragMonthly),
+        municipality: data.municipality || undefined,
+        pensionEmployeePct: data.pensionEmployeePct ? parseFloat(data.pensionEmployeePct) : undefined,
+        pensionEmployerPct: data.pensionEmployerPct ? parseFloat(data.pensionEmployerPct) : undefined,
+        atpAmount: data.atpAmount ? parseFloat(data.atpAmount) : undefined,
+        bruttoItems: data.bruttoItems.filter((i) => i.label && i.monthlyAmount).map((i) => ({ label: i.label, monthlyAmount: parseFloat(i.monthlyAmount) })),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['taxcards'] })
+      setShowTaxCardForm(false); setTaxCardForm(emptyTaxCard()); setTaxCardError('')
+      toast.success('Tax card settings saved')
+    },
+    onError: (err) => { if (axios.isAxiosError(err)) setTaxCardError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
   })
 
   const deleteOverrideMutation = useMutation({
@@ -395,6 +814,14 @@ export function IncomePage() {
 
   // ── Helpers ───────────────────────────────────────────────────────────────
 
+  function computeManualNet(gross: number, calc: LiveDeductions, overrides: DeductionOverrides): number {
+    const amBidrag = parseFloat(overrides.amBidragAmount) || calc.amBidrag
+    const aSkat = parseFloat(overrides.aSkattAmount) || calc.aSkat
+    const pension = parseFloat(overrides.pensionEmployeeAmount) || calc.pensionEmployee
+    const atp = parseFloat(overrides.atpAmount) || calc.atp
+    return r2(gross - calc.bruttoTotal - amBidrag - aSkat - pension - atp)
+  }
+
   function getAllocationPct(job: Job, householdId: string): string {
     const key = `${job.id}:${householdId}`
     if (key in pendingAllocations) return pendingAllocations[key]
@@ -413,7 +840,7 @@ export function IncomePage() {
   }
 
   function openEditJob(job: Job) {
-    setJobForm({ name: job.name, employer: job.employer ?? '', startDate: toDateInput(job.startDate), endDate: job.endDate ? toDateInput(job.endDate) : '' })
+    setJobForm({ name: job.name, employer: job.employer ?? '', country: job.country ?? 'DK', startDate: toDateInput(job.startDate), endDate: job.endDate ? toDateInput(job.endDate) : '' })
     setJobFormError('')
     setEditingJob(job)
   }
@@ -423,6 +850,49 @@ export function IncomePage() {
     if (editingJob) updateJobMutation.mutate(jobForm)
     else createJobMutation.mutate(jobForm)
   }
+
+  // ── DK tax card context ───────────────────────────────────────────────────
+
+  const salaryJob = jobs.find((j) => j.id === salaryJobId) ?? null
+  const overrideJob = jobs.find((j) => j.id === overrideJobId) ?? null
+
+  const activeTaxCard = useMemo((): TaxCardSettings | null => {
+    if (!salaryJobId) return null
+    const cards = taxCards[salaryJobId] ?? []
+    return cards.length > 0 ? cards[0] : null
+  }, [salaryJobId, taxCards])
+
+  const overrideActiveTaxCard = useMemo((): TaxCardSettings | null => {
+    if (!overrideJobId) return null
+    const cards = taxCards[overrideJobId] ?? []
+    return cards.length > 0 ? cards[0] : null
+  }, [overrideJobId, taxCards])
+
+  const salaryLiveCalc = useMemo((): LiveDeductions | null => {
+    const gross = parseFloat(salaryForm.grossAmount)
+    if (!salaryJob || salaryJob.country !== 'DK' || !activeTaxCard || !gross) return null
+    return calcDanishDeductions(gross, {
+      traekprocent: parseFloat(activeTaxCard.traekprocent),
+      personfradragMonthly: parseFloat(activeTaxCard.personfradragMonthly),
+      pensionEmployeePct: activeTaxCard.pensionEmployeePct ? parseFloat(activeTaxCard.pensionEmployeePct) : null,
+      pensionEmployerPct: activeTaxCard.pensionEmployerPct ? parseFloat(activeTaxCard.pensionEmployerPct) : null,
+      atpAmount: activeTaxCard.atpAmount ? parseFloat(activeTaxCard.atpAmount) : null,
+      bruttoItems: activeTaxCard.bruttoItems,
+    })
+  }, [salaryForm.grossAmount, salaryJob, activeTaxCard])
+
+  const overrideLiveCalc = useMemo((): LiveDeductions | null => {
+    const gross = parseFloat(overrideForm.grossAmount)
+    if (!overrideJob || overrideJob.country !== 'DK' || !overrideActiveTaxCard || !gross) return null
+    return calcDanishDeductions(gross, {
+      traekprocent: parseFloat(overrideActiveTaxCard.traekprocent),
+      personfradragMonthly: parseFloat(overrideActiveTaxCard.personfradragMonthly),
+      pensionEmployeePct: overrideActiveTaxCard.pensionEmployeePct ? parseFloat(overrideActiveTaxCard.pensionEmployeePct) : null,
+      pensionEmployerPct: overrideActiveTaxCard.pensionEmployerPct ? parseFloat(overrideActiveTaxCard.pensionEmployerPct) : null,
+      atpAmount: overrideActiveTaxCard.atpAmount ? parseFloat(overrideActiveTaxCard.atpAmount) : null,
+      bruttoItems: overrideActiveTaxCard.bruttoItems,
+    })
+  }, [overrideForm.grossAmount, overrideJob, overrideActiveTaxCard])
 
   // ── Chart data ────────────────────────────────────────────────────────────
 
@@ -566,6 +1036,25 @@ export function IncomePage() {
                         </div>
                       </div>
 
+                      {/* Tax card settings (DK only) */}
+                      {job.country === 'DK' && (
+                        <TaxCardSection
+                          jobId={job.id}
+                          cards={taxCards[job.id] ?? []}
+                          isExpanded={taxCardJobId === job.id}
+                          onToggle={() => setTaxCardJobId((prev) => prev === job.id ? null : job.id)}
+                          showForm={taxCardJobId === job.id && showTaxCardForm}
+                          onShowForm={() => { setShowTaxCardForm(true); setTaxCardForm(emptyTaxCard()) }}
+                          onHideForm={() => setShowTaxCardForm(false)}
+                          form={taxCardForm}
+                          onFormChange={setTaxCardForm}
+                          onSubmit={(e) => { e.preventDefault(); createTaxCardMutation.mutate(taxCardForm) }}
+                          isPending={createTaxCardMutation.isPending}
+                          error={taxCardError}
+                          fmt={fmt}
+                        />
+                      )}
+
                       {/* Allocations */}
                       {households.length > 0 && (
                         <div className="border-t border-gray-800 pt-4">
@@ -666,7 +1155,14 @@ export function IncomePage() {
                             <tbody>
                               {overrides.map((o) => (
                                 <tr key={o.id} className="border-b border-gray-800/50 last:border-0">
-                                  <td className="py-2 pr-4 text-white">{MONTHS[o.month - 1]} {o.year}</td>
+                                  <td className="py-2 pr-4 text-white">
+                                    <div className="flex items-center gap-2">
+                                      <span>{MONTHS[o.month - 1]} {o.year}</span>
+                                      {o.deductionsSource && (
+                                        <span className="text-xs bg-blue-900/50 text-blue-300 border border-blue-700 px-1.5 py-0.5 rounded">Payslip entered</span>
+                                      )}
+                                    </div>
+                                  </td>
                                   <td className="py-2 pr-4 text-gray-300 tabular-nums">{fmt(o.grossAmount)}</td>
                                   <td className="py-2 pr-4 text-amber-400 tabular-nums">{fmt(o.netAmount)}</td>
                                   <td className="py-2 pr-4 text-gray-500 text-xs">{o.note ?? '—'}</td>
@@ -783,6 +1279,13 @@ export function IncomePage() {
               <input type="text" value={jobForm.employer} onChange={(e) => setJobForm({ ...jobForm, employer: e.target.value })}
                 placeholder="e.g. Acme Corp" className={inputClass} />
             </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-400 mb-1">Country</label>
+              <select value={jobForm.country} onChange={(e) => setJobForm({ ...jobForm, country: e.target.value })} className={inputClass}>
+                <option value="DK">DK — Denmark</option>
+                <option value="OTHER">Other (generic)</option>
+              </select>
+            </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="block text-xs font-medium text-gray-400 mb-1">Start date</label>
@@ -851,8 +1354,8 @@ export function IncomePage() {
 
           {/* Add / Edit record */}
           <h3 className="text-sm font-medium text-gray-400 mb-3">{editingSalary ? 'Edit salary record' : 'Add salary record'}</h3>
-          <form onSubmit={(e) => { e.preventDefault(); editingSalary ? updateSalaryMutation.mutate(salaryForm) : addSalaryMutation.mutate(salaryForm) }} className="space-y-3">
-            <div className="grid grid-cols-4 gap-3">
+          <form onSubmit={(e) => { e.preventDefault(); const payload = { form: salaryForm, deductionOverrides: salaryDeductionOverrides, liveCalc: salaryLiveCalc }; editingSalary ? updateSalaryMutation.mutate(payload) : addSalaryMutation.mutate(payload) }} className="space-y-3">
+            <div className={`grid gap-3 ${salaryJob?.country === 'DK' ? 'grid-cols-3' : 'grid-cols-4'}`}>
               <div>
                 <label className="block text-xs font-medium text-gray-400 mb-1">Effective from</label>
                 <input type="date" value={salaryForm.effectiveFrom} onChange={(e) => setSalaryForm({ ...salaryForm, effectiveFrom: e.target.value })}
@@ -863,11 +1366,13 @@ export function IncomePage() {
                 <input type="number" value={salaryForm.grossAmount} onChange={(e) => setSalaryForm({ ...salaryForm, grossAmount: e.target.value })}
                   required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
               </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1">Net / month</label>
-                <input type="number" value={salaryForm.netAmount} onChange={(e) => setSalaryForm({ ...salaryForm, netAmount: e.target.value })}
-                  required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
-              </div>
+              {salaryJob?.country !== 'DK' && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-400 mb-1">Net / month</label>
+                  <input type="number" value={salaryForm.netAmount} onChange={(e) => setSalaryForm({ ...salaryForm, netAmount: e.target.value })}
+                    required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
+                </div>
+              )}
               <div>
                 <label className="block text-xs font-medium text-gray-400 mb-1">Currency</label>
                 <select value={salaryForm.currencyCode} onChange={(e) => setSalaryForm({ ...salaryForm, currencyCode: e.target.value })}
@@ -884,6 +1389,19 @@ export function IncomePage() {
                 ≈ {(parseFloat(salaryForm.netAmount) * (currencies.find((c) => c.code === salaryForm.currencyCode)?.rate ?? 1)).toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {baseCurrency} / month net
               </p>
             )}
+
+            {/* DK deduction breakdown panel */}
+            {salaryJob?.country === 'DK' && (
+              <DeductionPanel
+                gross={parseFloat(salaryForm.grossAmount) || 0}
+                liveCalc={salaryLiveCalc}
+                overrides={salaryDeductionOverrides}
+                onOverrideChange={(field, val) => setSalaryDeductionOverrides((prev) => ({ ...prev, [field]: val }))}
+                hasTaxCard={!!activeTaxCard}
+                baseCurrency={baseCurrency}
+              />
+            )}
+
             {salaryError && <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">{salaryError}</div>}
             <div className="flex items-center gap-3">
               <button type="submit" disabled={addSalaryMutation.isPending || updateSalaryMutation.isPending}
@@ -891,7 +1409,7 @@ export function IncomePage() {
                 {addSalaryMutation.isPending || updateSalaryMutation.isPending ? 'Saving…' : editingSalary ? 'Save changes' : 'Add record'}
               </button>
               {editingSalary && (
-                <button type="button" onClick={() => { setEditingSalary(null); setSalaryForm(emptySalary(baseCurrency)); setSalaryError('') }}
+                <button type="button" onClick={() => { setEditingSalary(null); setSalaryForm(emptySalary(baseCurrency)); setSalaryDeductionOverrides(emptyDeductionOverrides()); setSalaryError('') }}
                   className="text-sm text-gray-400 hover:text-white transition-colors">Cancel</button>
               )}
             </div>
@@ -901,8 +1419,8 @@ export function IncomePage() {
 
       {/* ── Add Override modal ──────────────────────────────────────────────── */}
       {overrideJobId && (
-        <Modal title={`Add monthly override — ${jobs.find((j) => j.id === overrideJobId)?.name}`} onClose={() => setOverrideJobId(null)}>
-          <form onSubmit={(e) => { e.preventDefault(); upsertOverrideMutation.mutate(overrideForm) }} className="space-y-4">
+        <Modal title={`Add monthly override — ${jobs.find((j) => j.id === overrideJobId)?.name}`} onClose={() => { setOverrideJobId(null); setOverrideDeductionOpen(false); setOverrideDeductionOverrides(emptyDeductionOverrides()) }}>
+          <form onSubmit={(e) => { e.preventDefault(); upsertOverrideMutation.mutate({ form: overrideForm, deductionOverrides: overrideDeductionOverrides, liveCalc: overrideLiveCalc }) }} className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="block text-xs font-medium text-gray-400 mb-1">Year</label>
@@ -916,16 +1434,20 @@ export function IncomePage() {
                 </select>
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1">Gross / month</label>
-                <input type="number" value={overrideForm.grossAmount} onChange={(e) => setOverrideForm({ ...overrideForm, grossAmount: e.target.value })}
-                  required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-400 mb-1">Net / month</label>
-                <input type="number" value={overrideForm.netAmount} onChange={(e) => setOverrideForm({ ...overrideForm, netAmount: e.target.value })}
-                  required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
+            <div className={`grid gap-4 ${overrideJob?.country === 'DK' ? 'grid-cols-1' : 'grid-cols-2'}`}>
+              <div className={overrideJob?.country === 'DK' ? 'grid grid-cols-2 gap-4' : ''}>
+                <div>
+                  <label className="block text-xs font-medium text-gray-400 mb-1">Gross / month</label>
+                  <input type="number" value={overrideForm.grossAmount} onChange={(e) => setOverrideForm({ ...overrideForm, grossAmount: e.target.value })}
+                    required min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
+                </div>
+                {overrideJob?.country !== 'DK' && (
+                  <div>
+                    <label className="block text-xs font-medium text-gray-400 mb-1">Net / month</label>
+                    <input type="number" value={overrideForm.netAmount} onChange={(e) => setOverrideForm({ ...overrideForm, netAmount: e.target.value })}
+                      required={overrideJob?.country !== 'DK'} min="0.01" step="0.01" placeholder="0.00" className={inputClass} />
+                  </div>
+                )}
               </div>
             </div>
             <div>
@@ -933,13 +1455,37 @@ export function IncomePage() {
               <input type="text" value={overrideForm.note} onChange={(e) => setOverrideForm({ ...overrideForm, note: e.target.value })}
                 placeholder="e.g. Sick leave, parental leave" className={inputClass} />
             </div>
+
+            {/* Deduction breakdown for DK jobs */}
+            {overrideJob?.country === 'DK' && (
+              <div className="border border-gray-700 rounded-lg overflow-hidden">
+                <button type="button" onClick={() => setOverrideDeductionOpen((v) => !v)}
+                  className="w-full flex items-center justify-between px-4 py-2.5 text-sm text-gray-400 hover:text-white hover:bg-gray-800 transition-colors">
+                  <span>Deduction breakdown</span>
+                  <span className="text-xs">{overrideDeductionOpen ? '▲' : '▼'}</span>
+                </button>
+                {overrideDeductionOpen && (
+                  <div className="p-4 border-t border-gray-700">
+                    <DeductionPanel
+                      gross={parseFloat(overrideForm.grossAmount) || 0}
+                      liveCalc={overrideLiveCalc}
+                      overrides={overrideDeductionOverrides}
+                      onOverrideChange={(field, val) => setOverrideDeductionOverrides((prev) => ({ ...prev, [field]: val }))}
+                      hasTaxCard={!!overrideActiveTaxCard}
+                      baseCurrency={baseCurrency}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+
             {overrideError && <div className="bg-red-950 border border-red-800 text-red-300 px-4 py-3 rounded-lg text-sm">{overrideError}</div>}
             <div className="flex gap-3 pt-2">
               <button type="submit" disabled={upsertOverrideMutation.isPending}
                 className="flex-1 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-gray-950 font-semibold rounded-lg px-4 py-2.5 text-sm transition-colors">
                 {upsertOverrideMutation.isPending ? 'Saving…' : 'Save override'}
               </button>
-              <button type="button" onClick={() => setOverrideJobId(null)}
+              <button type="button" onClick={() => { setOverrideJobId(null); setOverrideDeductionOpen(false); setOverrideDeductionOverrides(emptyDeductionOverrides()) }}
                 className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 rounded-lg px-4 py-2.5 text-sm transition-colors">Cancel</button>
             </div>
           </form>

--- a/apps/web/src/pages/IncomePage.tsx
+++ b/apps/web/src/pages/IncomePage.tsx
@@ -186,27 +186,35 @@ function r2(n: number) { return Math.round(n * 100) / 100 }
 
 interface LiveDeductions {
   amBidrag: number; aSkat: number; topSkat: number; atp: number
-  pensionEmployee: number; pensionEmployer: number; bruttoTotal: number; net: number
+  pensionEmployee: number; pensionEmployer: number; bruttoTotal: number; bruttoItems: { label: string; monthlyAmount: number }[]; net: number
 }
 
+/**
+ * Correct Danish payroll calculation order:
+ *   1. Pre-AM: brutto items + pension employee + ATP → all reduce AM base
+ *   2. AM-bidrag = 8% of AM-indkomst (truncated to whole DKK)
+ *   3. A-skat = bottom tax + top-skat (both truncated to whole DKK)
+ *   4. Net = gross − preAmTotal − amBidrag − aSkat
+ */
 function calcDanishDeductions(
   gross: number,
   settings: { traekprocent: number; personfradragMonthly: number; pensionEmployeePct?: number | null; pensionEmployerPct?: number | null; atpAmount?: number | null; bruttoItems?: { label: string; monthlyAmount: number }[] | null }
 ): LiveDeductions {
-  const items = settings.bruttoItems ?? []
-  const bruttoTotal = r2(items.reduce((s, i) => s + i.monthlyAmount, 0))
-  const taxableGross = gross - bruttoTotal
-  const amBidrag = r2(taxableGross * AM_BIDRAG_RATE)
-  const aIndkomst = taxableGross - amBidrag
-  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
-  const bottomTax = r2(taxableBase * settings.traekprocent / 100)
-  const topSkat = r2(Math.max(0, aIndkomst - TOP_SKAT_THRESHOLD) * TOP_SKAT_RATE)
-  const aSkat = bottomTax + topSkat
-  const atp = r2(settings.atpAmount ?? DEFAULT_ATP)
+  const bruttoItems = settings.bruttoItems ?? []
+  const bruttoTotal = r2(bruttoItems.reduce((s, i) => s + i.monthlyAmount, 0))
   const pensionEmployee = settings.pensionEmployeePct ? r2(gross * settings.pensionEmployeePct / 100) : 0
+  const atp = Math.floor(settings.atpAmount ?? DEFAULT_ATP)
+  const preAmTotal = r2(bruttoTotal + pensionEmployee + atp)
+  const amBase = gross - preAmTotal
+  const amBidrag = Math.floor(amBase * AM_BIDRAG_RATE)
+  const aIndkomst = amBase - amBidrag
+  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
+  const bottomTax = Math.floor(taxableBase * settings.traekprocent / 100)
+  const topSkat = Math.floor(Math.max(0, aIndkomst - TOP_SKAT_THRESHOLD) * TOP_SKAT_RATE)
+  const aSkat = bottomTax + topSkat
   const pensionEmployer = settings.pensionEmployerPct ? r2(gross * settings.pensionEmployerPct / 100) : 0
-  const net = r2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
-  return { amBidrag, aSkat, topSkat, atp, pensionEmployee, pensionEmployer, bruttoTotal, net }
+  const net = r2(gross - preAmTotal - amBidrag - aSkat)
+  return { amBidrag, aSkat, topSkat, atp, pensionEmployee, pensionEmployer, bruttoTotal, bruttoItems, net }
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -327,7 +335,9 @@ interface TaxCardSectionProps {
   isExpanded: boolean
   onToggle: () => void
   showForm: boolean
+  editingCardId: string | null
   onShowForm: () => void
+  onEditCard: (card: TaxCardSettings) => void
   onHideForm: () => void
   form: TaxCardForm
   onFormChange: (f: TaxCardForm) => void
@@ -337,7 +347,7 @@ interface TaxCardSectionProps {
   fmt: (v: number | string) => string
 }
 
-function TaxCardSection({ jobId: _jobId, cards, isExpanded, onToggle, showForm, onShowForm, onHideForm, form, onFormChange, onSubmit, isPending, error, fmt }: TaxCardSectionProps) {
+function TaxCardSection({ jobId: _jobId, cards, isExpanded, onToggle, showForm, editingCardId, onShowForm, onEditCard, onHideForm, form, onFormChange, onSubmit, isPending, error, fmt }: TaxCardSectionProps) {
   const activeCard = cards[0] ?? null
   return (
     <div className="border-t border-gray-800 pt-4 mt-2">
@@ -358,6 +368,10 @@ function TaxCardSection({ jobId: _jobId, cards, isExpanded, onToggle, showForm, 
                       {new Date(card.effectiveFrom).toLocaleDateString('en', { year: 'numeric', month: 'short', day: 'numeric' })}
                     </span>
                     {i === 0 && <span className="text-xs bg-green-900/50 text-green-400 border border-green-700 px-1.5 py-0.5 rounded">Active</span>}
+                    <button type="button" onClick={() => onEditCard(card)}
+                      className="ml-auto text-xs text-gray-500 hover:text-amber-400 transition-colors px-1.5 py-0.5 rounded border border-transparent hover:border-amber-700">
+                      Edit
+                    </button>
                   </div>
                   <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs text-gray-400">
                     <span>Trækprocent: <span className="text-white">{parseFloat(card.traekprocent).toFixed(2)}%</span></span>
@@ -382,7 +396,7 @@ function TaxCardSection({ jobId: _jobId, cards, isExpanded, onToggle, showForm, 
             </button>
           ) : (
             <form onSubmit={onSubmit} className="bg-gray-800 rounded-lg p-4 space-y-3">
-              <p className="text-xs font-medium text-gray-300 mb-2">New tax card settings</p>
+              <p className="text-xs font-medium text-gray-300 mb-2">{editingCardId ? 'Edit tax card settings' : 'New tax card settings'}</p>
               <div className="grid grid-cols-3 gap-3">
                 <div>
                   <label className="block text-xs text-gray-400 mb-1">Effective from</label>
@@ -506,6 +520,7 @@ export function IncomePage() {
   const [showTaxCardForm, setShowTaxCardForm] = useState(false)
   const [taxCardForm, setTaxCardForm] = useState<TaxCardForm>(emptyTaxCard())
   const [taxCardError, setTaxCardError] = useState('')
+  const [editingTaxCardId, setEditingTaxCardId] = useState<string | null>(null)
 
   // Deduction overrides (salary + override forms)
   const [salaryDeductionOverrides, setSalaryDeductionOverrides] = useState<DeductionOverrides>(emptyDeductionOverrides())
@@ -645,12 +660,8 @@ export function IncomePage() {
   const addSalaryMutation = useMutation({
     mutationFn: ({ form, deductionOverrides, liveCalc }: { form: SalaryForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
       const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
-      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
-        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
-        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
-        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
-        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
-        deductionsSource: 'MANUAL',
+      const deductionPayload = (liveCalc && hasManualOverride) ? {
+        payslipLines: buildPayslipLines(liveCalc, deductionOverrides),
       } : {}
       const net = liveCalc
         ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
@@ -673,12 +684,8 @@ export function IncomePage() {
   const updateSalaryMutation = useMutation({
     mutationFn: ({ form, deductionOverrides, liveCalc }: { form: SalaryForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
       const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
-      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
-        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
-        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
-        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
-        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
-        deductionsSource: 'MANUAL',
+      const deductionPayload = (liveCalc && hasManualOverride) ? {
+        payslipLines: buildPayslipLines(liveCalc, deductionOverrides),
       } : {}
       const net = liveCalc
         ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
@@ -710,12 +717,8 @@ export function IncomePage() {
   const upsertOverrideMutation = useMutation({
     mutationFn: ({ form, deductionOverrides, liveCalc }: { form: OverrideForm; deductionOverrides: DeductionOverrides; liveCalc: LiveDeductions | null }) => {
       const hasManualOverride = Object.values(deductionOverrides).some((v) => v !== '')
-      const deductionPayload = liveCalc && !hasManualOverride ? {} : liveCalc ? {
-        amBidragAmount: parseFloat(deductionOverrides.amBidragAmount) || liveCalc.amBidrag,
-        aSkattAmount: parseFloat(deductionOverrides.aSkattAmount) || liveCalc.aSkat,
-        pensionEmployeeAmount: parseFloat(deductionOverrides.pensionEmployeeAmount) || liveCalc.pensionEmployee || undefined,
-        atpAmount: parseFloat(deductionOverrides.atpAmount) || liveCalc.atp,
-        deductionsSource: 'MANUAL',
+      const deductionPayload = (liveCalc && hasManualOverride) ? {
+        payslipLines: buildPayslipLines(liveCalc, deductionOverrides),
       } : {}
       const net = liveCalc
         ? (hasManualOverride ? computeManualNet(parseFloat(form.grossAmount), liveCalc, deductionOverrides) : liveCalc.net)
@@ -736,24 +739,37 @@ export function IncomePage() {
     onError: (err) => { if (axios.isAxiosError(err)) setOverrideError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
   })
 
+  function buildTaxCardPayload(data: TaxCardForm) {
+    return {
+      effectiveFrom: data.effectiveFrom,
+      traekprocent: parseFloat(data.traekprocent),
+      personfradragMonthly: parseFloat(data.personfradragMonthly),
+      municipality: data.municipality || undefined,
+      pensionEmployeePct: data.pensionEmployeePct ? parseFloat(data.pensionEmployeePct) : undefined,
+      pensionEmployerPct: data.pensionEmployerPct ? parseFloat(data.pensionEmployerPct) : undefined,
+      atpAmount: data.atpAmount ? parseFloat(data.atpAmount) : undefined,
+      bruttoItems: data.bruttoItems.filter((i) => i.label && i.monthlyAmount).map((i) => ({ label: i.label, monthlyAmount: parseFloat(i.monthlyAmount) })),
+    }
+  }
+
   const createTaxCardMutation = useMutation({
-    mutationFn: (data: TaxCardForm) =>
-      api.post(`/jobs/${taxCardJobId}/taxcard`, {
-        effectiveFrom: data.effectiveFrom,
-        traekprocent: parseFloat(data.traekprocent),
-        personfradragMonthly: parseFloat(data.personfradragMonthly),
-        municipality: data.municipality || undefined,
-        pensionEmployeePct: data.pensionEmployeePct ? parseFloat(data.pensionEmployeePct) : undefined,
-        pensionEmployerPct: data.pensionEmployerPct ? parseFloat(data.pensionEmployerPct) : undefined,
-        atpAmount: data.atpAmount ? parseFloat(data.atpAmount) : undefined,
-        bruttoItems: data.bruttoItems.filter((i) => i.label && i.monthlyAmount).map((i) => ({ label: i.label, monthlyAmount: parseFloat(i.monthlyAmount) })),
-      }),
+    mutationFn: (data: TaxCardForm) => api.post(`/jobs/${taxCardJobId}/taxcard`, buildTaxCardPayload(data)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['taxcards'] })
       setShowTaxCardForm(false); setTaxCardForm(emptyTaxCard()); setTaxCardError('')
       toast.success('Tax card settings saved')
     },
     onError: (err) => { if (axios.isAxiosError(err)) setTaxCardError((err.response?.data as { error?: string })?.error ?? 'Failed to save') },
+  })
+
+  const updateTaxCardMutation = useMutation({
+    mutationFn: (data: TaxCardForm) => api.put(`/jobs/${taxCardJobId}/taxcard/${editingTaxCardId}`, buildTaxCardPayload(data)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['taxcards'] })
+      setEditingTaxCardId(null); setShowTaxCardForm(false); setTaxCardForm(emptyTaxCard()); setTaxCardError('')
+      toast.success('Tax card updated')
+    },
+    onError: (err) => { if (axios.isAxiosError(err)) setTaxCardError((err.response?.data as { error?: string })?.error ?? 'Failed to update') },
   })
 
   const deleteOverrideMutation = useMutation({
@@ -815,11 +831,30 @@ export function IncomePage() {
   // ── Helpers ───────────────────────────────────────────────────────────────
 
   function computeManualNet(gross: number, calc: LiveDeductions, overrides: DeductionOverrides): number {
-    const amBidrag = parseFloat(overrides.amBidragAmount) || calc.amBidrag
-    const aSkat = parseFloat(overrides.aSkattAmount) || calc.aSkat
     const pension = parseFloat(overrides.pensionEmployeeAmount) || calc.pensionEmployee
     const atp = parseFloat(overrides.atpAmount) || calc.atp
-    return r2(gross - calc.bruttoTotal - amBidrag - aSkat - pension - atp)
+    const amBidrag = parseFloat(overrides.amBidragAmount) || calc.amBidrag
+    const aSkat = parseFloat(overrides.aSkattAmount) || calc.aSkat
+    return r2(gross - calc.bruttoTotal - pension - atp - amBidrag - aSkat)
+  }
+
+  function buildPayslipLines(calc: LiveDeductions, overrides: DeductionOverrides) {
+    type LineType = 'benefit_in_kind' | 'pre_am' | 'am_bidrag' | 'a_skat' | 'post_tax'
+    const lines: { label: string; amount: number; type: LineType; sankeyGroup?: string; isCalculated: boolean }[] = []
+    for (const item of calc.bruttoItems) {
+      lines.push({ label: item.label, amount: item.monthlyAmount, type: 'pre_am', sankeyGroup: 'brutto_benefits', isCalculated: true })
+    }
+    const pension = parseFloat(overrides.pensionEmployeeAmount) || 0
+    if (pension > 0 || calc.pensionEmployee > 0) {
+      lines.push({ label: 'Pension (employee)', amount: pension || calc.pensionEmployee, type: 'pre_am', sankeyGroup: 'pension_employee', isCalculated: !overrides.pensionEmployeeAmount })
+    }
+    const atpVal = parseFloat(overrides.atpAmount) || 0
+    lines.push({ label: 'ATP', amount: atpVal || calc.atp, type: 'pre_am', sankeyGroup: 'atp', isCalculated: !overrides.atpAmount })
+    const amBidragVal = parseFloat(overrides.amBidragAmount) || 0
+    lines.push({ label: 'AM-bidrag (8%)', amount: amBidragVal || calc.amBidrag, type: 'am_bidrag', sankeyGroup: 'am_bidrag', isCalculated: !overrides.amBidragAmount })
+    const aSkatVal = parseFloat(overrides.aSkattAmount) || 0
+    lines.push({ label: 'A-skat', amount: aSkatVal || calc.aSkat, type: 'a_skat', sankeyGroup: 'a_skat', isCalculated: !overrides.aSkattAmount })
+    return lines
   }
 
   function getAllocationPct(job: Job, householdId: string): string {
@@ -1044,12 +1079,32 @@ export function IncomePage() {
                           isExpanded={taxCardJobId === job.id}
                           onToggle={() => setTaxCardJobId((prev) => prev === job.id ? null : job.id)}
                           showForm={taxCardJobId === job.id && showTaxCardForm}
-                          onShowForm={() => { setShowTaxCardForm(true); setTaxCardForm(emptyTaxCard()) }}
-                          onHideForm={() => setShowTaxCardForm(false)}
+                          editingCardId={editingTaxCardId}
+                          onShowForm={() => { setEditingTaxCardId(null); setShowTaxCardForm(true); setTaxCardForm(emptyTaxCard()) }}
+                          onEditCard={(card) => {
+                            setEditingTaxCardId(card.id)
+                            setShowTaxCardForm(true)
+                            setTaxCardForm({
+                              effectiveFrom: new Date(card.effectiveFrom).toISOString().slice(0, 10),
+                              traekprocent: card.traekprocent,
+                              personfradragMonthly: card.personfradragMonthly,
+                              municipality: card.municipality ?? '',
+                              pensionEmployeePct: card.pensionEmployeePct ?? '',
+                              pensionEmployerPct: card.pensionEmployerPct ?? '',
+                              atpAmount: card.atpAmount ?? '',
+                              bruttoItems: card.bruttoItems?.map((b) => ({ label: b.label, monthlyAmount: String(b.monthlyAmount) })) ?? [],
+                            })
+                          }}
+                          onHideForm={() => { setShowTaxCardForm(false); setEditingTaxCardId(null) }}
                           form={taxCardForm}
                           onFormChange={setTaxCardForm}
-                          onSubmit={(e) => { e.preventDefault(); createTaxCardMutation.mutate(taxCardForm) }}
-                          isPending={createTaxCardMutation.isPending}
+                          onSubmit={(e) => {
+                            e.preventDefault()
+                            editingTaxCardId
+                              ? updateTaxCardMutation.mutate(taxCardForm)
+                              : createTaxCardMutation.mutate(taxCardForm)
+                          }}
+                          isPending={createTaxCardMutation.isPending || updateTaxCardMutation.isPending}
                           error={taxCardError}
                           fmt={fmt}
                         />

--- a/apps/web/src/pages/UserDashboardPage.tsx
+++ b/apps/web/src/pages/UserDashboardPage.tsx
@@ -86,6 +86,7 @@ interface IncomeTrend {
 
 interface IncomeSankeyData {
   totalIncome: string
+  employerPensionMonthly?: string
   nodes: { id: string; name: string; color?: string }[]
   links: { source: string; target: string; value: number }[]
 }
@@ -367,7 +368,17 @@ export function UserDashboardPage() {
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 mb-6">
               <h3 className="text-sm font-semibold mb-4 text-gray-200">Income flow</h3>
               {sankeyData && sankeyData.nodes.length > 0 ? (
-                <SankeyChart data={sankeyData} currency={baseCurrency} />
+                <>
+                  {(() => {
+                    const has3Col = sankeyData.nodes.some((n) => n.id === 'net_pay' || n.id === 'am_bidrag')
+                    return <SankeyChart data={sankeyData} currency={baseCurrency} height={has3Col ? 480 : 400} />
+                  })()}
+                  {sankeyData.employerPensionMonthly && parseFloat(sankeyData.employerPensionMonthly) > 0 && (
+                    <p className="text-xs text-gray-500 mt-3">
+                      ℹ Employer pension: <span className="text-gray-300">{parseFloat(sankeyData.employerPensionMonthly).toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {baseCurrency}/month</span> (paid directly to pension fund)
+                    </p>
+                  )}
+                </>
               ) : (
                 <p className="text-gray-500 text-sm">No allocation data. Allocate income to households first.</p>
               )}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,21 +5,15 @@ export interface BruttoItem {
   monthlyAmount: number
 }
 
-export interface OtherDeductionItem {
+export type PayslipLineType = 'benefit_in_kind' | 'pre_am' | 'am_bidrag' | 'a_skat' | 'post_tax'
+export type SankeyGroup = 'brutto_benefits' | 'am_bidrag' | 'a_skat' | 'pension_employee' | 'atp' | 'other_deductions'
+
+export interface PayslipLine {
   label: string
   amount: number
-}
-
-/** Payslip deduction breakdown — present on SalaryRecord and MonthlyIncomeOverride */
-export interface DeductionFields {
-  amBidragAmount?: number | null
-  aSkattAmount?: number | null
-  pensionEmployeeAmount?: number | null
-  pensionEmployerAmount?: number | null
-  atpAmount?: number | null
-  bruttoDeductionAmount?: number | null
-  otherDeductions?: OtherDeductionItem[] | null
-  deductionsSource?: 'MANUAL' | 'CALCULATED' | null
+  type: PayslipLineType
+  sankeyGroup?: SankeyGroup
+  isCalculated: boolean
 }
 
 export interface TaxCardSettingsData {
@@ -34,7 +28,6 @@ export interface TaxCardSettingsData {
 
 // ── Danish tax calculation (for frontend live preview) ────────────────────────
 
-/** Stripped-down version of TaxCardInput — no Prisma types */
 export interface TaxCalcInput {
   traekprocent: number
   personfradragMonthly: number
@@ -45,14 +38,16 @@ export interface TaxCalcInput {
 }
 
 export interface TaxCalcResult {
+  lines: PayslipLine[]
+  pensionEmployer: number
+  net: number
+  // Convenience fields for UI rendering (derived from lines)
   amBidrag: number
   aSkat: number
   topSkat: number
   atp: number
   pensionEmployee: number
-  pensionEmployer: number
   bruttoTotal: number
-  net: number
   isApproximate: true
 }
 
@@ -66,30 +61,57 @@ function _r2(n: number): number {
   return Math.round(n * 100) / 100
 }
 
+/**
+ * Calculate Danish payroll deductions for a given gross monthly salary.
+ *
+ * Correct calculation order (matching real Danish payroll):
+ *   1. Pre-AM: bruttolønsordning + pension employee % + ATP → all reduce AM base
+ *   2. AM-bidrag = 8% of AM-indkomst (truncated to whole DKK)
+ *   3. A-skat = bottom tax + top-skat (both truncated to whole DKK)
+ *   4. Net = gross − preAmTotal − amBidrag − aSkat
+ */
 export function calcDanishDeductions(gross: number, settings: TaxCalcInput): TaxCalcResult {
+  const lines: PayslipLine[] = []
+
+  // Pre-AM deductions
   const bruttoItems = settings.bruttoItems ?? []
   const bruttoTotal = _r2(bruttoItems.reduce((s, i) => s + i.monthlyAmount, 0))
-  const taxableGross = gross - bruttoTotal
+  for (const item of bruttoItems) {
+    lines.push({ label: item.label, amount: item.monthlyAmount, type: 'pre_am', sankeyGroup: 'brutto_benefits', isCalculated: true })
+  }
 
-  const amBidrag = _r2(taxableGross * _AM_BIDRAG_RATE)
-  const aIndkomst = taxableGross - amBidrag
+  const pensionEmployee = settings.pensionEmployeePct ? _r2(gross * settings.pensionEmployeePct / 100) : 0
+  if (pensionEmployee > 0) {
+    lines.push({ label: 'Pension (employee)', amount: pensionEmployee, type: 'pre_am', sankeyGroup: 'pension_employee', isCalculated: true })
+  }
 
+  const atp = Math.floor(settings.atpAmount ?? _DEFAULT_ATP)
+  if (atp > 0) {
+    lines.push({ label: 'ATP', amount: atp, type: 'pre_am', sankeyGroup: 'atp', isCalculated: true })
+  }
+
+  const preAmTotal = _r2(bruttoTotal + pensionEmployee + atp)
+
+  // AM-bidrag — truncated to whole DKK
+  const amBase = gross - preAmTotal
+  const amBidrag = Math.floor(amBase * _AM_BIDRAG_RATE)
+  lines.push({ label: 'AM-bidrag (8%)', amount: amBidrag, type: 'am_bidrag', sankeyGroup: 'am_bidrag', isCalculated: true })
+
+  // A-skat — truncated to whole DKK
+  const aIndkomst = amBase - amBidrag
   const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
-  const bottomTax = _r2(taxableBase * settings.traekprocent / 100)
-  const topSkat = _r2(Math.max(0, aIndkomst - _TOP_SKAT_THRESHOLD) * _TOP_SKAT_RATE)
+  const bottomTax = Math.floor(taxableBase * settings.traekprocent / 100)
+  const topSkat = Math.floor(Math.max(0, aIndkomst - _TOP_SKAT_THRESHOLD) * _TOP_SKAT_RATE)
   const aSkat = bottomTax + topSkat
+  lines.push({
+    label: topSkat > 0 ? `A-skat (incl. top-skat ${topSkat})` : 'A-skat',
+    amount: aSkat, type: 'a_skat', sankeyGroup: 'a_skat', isCalculated: true,
+  })
 
-  const atp = _r2(settings.atpAmount ?? _DEFAULT_ATP)
-  const pensionEmployee = settings.pensionEmployeePct
-    ? _r2(gross * settings.pensionEmployeePct / 100)
-    : 0
-  const pensionEmployer = settings.pensionEmployerPct
-    ? _r2(gross * settings.pensionEmployerPct / 100)
-    : 0
+  const pensionEmployer = settings.pensionEmployerPct ? _r2(gross * settings.pensionEmployerPct / 100) : 0
+  const net = _r2(gross - preAmTotal - amBidrag - aSkat)
 
-  const net = _r2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
-
-  return { amBidrag, aSkat, topSkat, atp, pensionEmployee, pensionEmployer, bruttoTotal, net, isApproximate: true }
+  return { lines, pensionEmployer, net, amBidrag, aSkat, topSkat, atp, pensionEmployee, bruttoTotal, isApproximate: true }
 }
 
 export const Frequency = {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,6 +32,66 @@ export interface TaxCardSettingsData {
   bruttoItems?: BruttoItem[] | null
 }
 
+// ── Danish tax calculation (for frontend live preview) ────────────────────────
+
+/** Stripped-down version of TaxCardInput — no Prisma types */
+export interface TaxCalcInput {
+  traekprocent: number
+  personfradragMonthly: number
+  pensionEmployeePct?: number | null
+  pensionEmployerPct?: number | null
+  atpAmount?: number | null
+  bruttoItems?: BruttoItem[] | null
+}
+
+export interface TaxCalcResult {
+  amBidrag: number
+  aSkat: number
+  topSkat: number
+  atp: number
+  pensionEmployee: number
+  pensionEmployer: number
+  bruttoTotal: number
+  net: number
+  isApproximate: true
+}
+
+// 2024 constants
+const _TOP_SKAT_THRESHOLD = 49_075
+const _TOP_SKAT_RATE = 0.15
+const _AM_BIDRAG_RATE = 0.08
+const _DEFAULT_ATP = 99
+
+function _r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export function calcDanishDeductions(gross: number, settings: TaxCalcInput): TaxCalcResult {
+  const bruttoItems = settings.bruttoItems ?? []
+  const bruttoTotal = _r2(bruttoItems.reduce((s, i) => s + i.monthlyAmount, 0))
+  const taxableGross = gross - bruttoTotal
+
+  const amBidrag = _r2(taxableGross * _AM_BIDRAG_RATE)
+  const aIndkomst = taxableGross - amBidrag
+
+  const taxableBase = Math.max(0, aIndkomst - settings.personfradragMonthly)
+  const bottomTax = _r2(taxableBase * settings.traekprocent / 100)
+  const topSkat = _r2(Math.max(0, aIndkomst - _TOP_SKAT_THRESHOLD) * _TOP_SKAT_RATE)
+  const aSkat = bottomTax + topSkat
+
+  const atp = _r2(settings.atpAmount ?? _DEFAULT_ATP)
+  const pensionEmployee = settings.pensionEmployeePct
+    ? _r2(gross * settings.pensionEmployeePct / 100)
+    : 0
+  const pensionEmployer = settings.pensionEmployerPct
+    ? _r2(gross * settings.pensionEmployerPct / 100)
+    : 0
+
+  const net = _r2(gross - bruttoTotal - amBidrag - aSkat - atp - pensionEmployee)
+
+  return { amBidrag, aSkat, topSkat, atp, pensionEmployee, pensionEmployer, bruttoTotal, net, isApproximate: true }
+}
+
 export const Frequency = {
   WEEKLY: 'WEEKLY',
   FORTNIGHTLY: 'FORTNIGHTLY',

--- a/prisma/migrations/20260411010000_payslip_lines/migration.sql
+++ b/prisma/migrations/20260411010000_payslip_lines/migration.sql
@@ -1,0 +1,35 @@
+-- PAY-002 rework: replace 7 individual deduction columns with payslipLines JSON
+-- Fixes: pension employee + ATP are pre-AM deductions (reduce AM base before AM-bidrag)
+-- Adds pensionEmployerMonthly as separate field (employer cost, not deducted from net)
+
+-- SalaryRecord: drop old columns, add new
+ALTER TABLE "SalaryRecord"
+  DROP COLUMN IF EXISTS "amBidragAmount",
+  DROP COLUMN IF EXISTS "aSkattAmount",
+  DROP COLUMN IF EXISTS "pensionEmployeeAmount",
+  DROP COLUMN IF EXISTS "pensionEmployerAmount",
+  DROP COLUMN IF EXISTS "atpAmount",
+  DROP COLUMN IF EXISTS "bruttoDeductionAmount",
+  DROP COLUMN IF EXISTS "otherDeductions";
+
+ALTER TABLE "SalaryRecord"
+  ADD COLUMN "payslipLines"           JSONB,
+  ADD COLUMN "pensionEmployerMonthly" DECIMAL(10,2);
+
+-- MonthlyIncomeOverride: drop old columns, add new
+ALTER TABLE "MonthlyIncomeOverride"
+  DROP COLUMN IF EXISTS "amBidragAmount",
+  DROP COLUMN IF EXISTS "aSkattAmount",
+  DROP COLUMN IF EXISTS "pensionEmployeeAmount",
+  DROP COLUMN IF EXISTS "pensionEmployerAmount",
+  DROP COLUMN IF EXISTS "atpAmount",
+  DROP COLUMN IF EXISTS "bruttoDeductionAmount",
+  DROP COLUMN IF EXISTS "otherDeductions";
+
+ALTER TABLE "MonthlyIncomeOverride"
+  ADD COLUMN "payslipLines"           JSONB,
+  ADD COLUMN "pensionEmployerMonthly" DECIMAL(10,2);
+
+-- Reset deductionsSource on existing rows (values were calculated with buggy order)
+UPDATE "SalaryRecord" SET "deductionsSource" = NULL WHERE "deductionsSource" IS NOT NULL;
+UPDATE "MonthlyIncomeOverride" SET "deductionsSource" = NULL WHERE "deductionsSource" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,14 +207,9 @@ model SalaryRecord {
   currencyCode   String?
   rateUsed       Decimal? @db.Decimal(18, 6)
   // Payslip deduction breakdown
-  amBidragAmount        Decimal? @db.Decimal(10, 2)
-  aSkattAmount          Decimal? @db.Decimal(10, 2)
-  pensionEmployeeAmount Decimal? @db.Decimal(10, 2)
-  pensionEmployerAmount Decimal? @db.Decimal(10, 2)
-  atpAmount             Decimal? @db.Decimal(10, 2)
-  bruttoDeductionAmount Decimal? @db.Decimal(10, 2)
-  otherDeductions       Json?
-  deductionsSource      String?
+  payslipLines           Json?
+  pensionEmployerMonthly Decimal? @db.Decimal(10, 2)
+  deductionsSource       String?
   createdAt      DateTime @default(now())
 
   @@index([jobId, effectiveFrom])
@@ -230,14 +225,9 @@ model MonthlyIncomeOverride {
   netAmount   Decimal  @db.Decimal(10, 2)
   note        String?
   // Payslip deduction breakdown
-  amBidragAmount        Decimal? @db.Decimal(10, 2)
-  aSkattAmount          Decimal? @db.Decimal(10, 2)
-  pensionEmployeeAmount Decimal? @db.Decimal(10, 2)
-  pensionEmployerAmount Decimal? @db.Decimal(10, 2)
-  atpAmount             Decimal? @db.Decimal(10, 2)
-  bruttoDeductionAmount Decimal? @db.Decimal(10, 2)
-  otherDeductions       Json?
-  deductionsSource      String?
+  payslipLines           Json?
+  pensionEmployerMonthly Decimal? @db.Decimal(10, 2)
+  deductionsSource       String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

- **Sprint 25 (#169–172)**: `Job.country`, `TaxCardSettings` model, deduction fields on `SalaryRecord` and `MonthlyIncomeOverride`, tax card CRUD API
- **Sprint 26 (#173–175)**: Danish tax calculation engine (`taxCalcDK.ts`), auto-calculate deductions on salary/override save, granular 3-column Sankey endpoint
- **Sprint 27 (#176–180)**: Country selector on job form, tax card settings UI, `DeductionPanel` with per-line overrides, monthly override deduction section, 3-column Sankey visualisation
- **PAY-002 rework**: Replace 7 individual deduction columns with `payslipLines Json?` + `pensionEmployerMonthly`; fix calculation order (pension + ATP are pre-AM, AM-bidrag and A-skat truncated to whole DKK); tax card records now editable in frontend

## Closes

Closes #169, #170, #171, #172, #173, #174, #175, #176, #177, #178, #179, #180

## Key decisions

- `payslipLines` JSON array allows arbitrary payslip structures (benefit-in-kind, post-tax deductions, multi-employer, etc.) without future schema changes
- `pensionEmployerMonthly` separated from employee deductions — employer cost is not deducted from net pay
- Pension employee + ATP reduce the AM base **before** AM-bidrag (matches real SKAT rules); previous implementation was incorrect
- AM-bidrag and A-skat use `Math.floor` (not round) to match real payroll system output
- Calculated net always wins on save when a tax card exists — stale manually-entered net cannot persist after a re-save
- Migration resets `deductionsSource = NULL` on all existing rows; they recalculate with the corrected formula on next save

## Test plan

- [ ] Add a DK job → add tax card (trækprocent, personfradrag, pension %) → add salary record: verify deduction panel shows correct values and Sankey switches to 3-column
- [ ] Edit an existing salary record: verify calculated net overwrites stored net
- [ ] Override a month: verify deduction section appears and saves correctly
- [ ] Edit a tax card record: verify form pre-fills and `PUT` updates the record
- [ ] Non-DK job: verify no deduction panel, no tax card section, Sankey stays 2-column
- [ ] Verify AM-bidrag = floor(amBase × 0.08) and A-skat = floor(taxableBase × trækprocent/100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)