### PR TITLE
fix: household summary tile layout and stale net income

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -292,15 +292,24 @@ export function DashboardPage() {
           <div className="grid grid-cols-2 gap-4 mb-8 sm:grid-cols-4">
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
               <p className="text-gray-400 text-xs uppercase tracking-wide mb-1">Income / mo</p>
-              <p className="text-2xl font-bold text-amber-400">{fmt(income)}</p>
+              <p className="text-2xl font-bold text-amber-400 tabular-nums">
+                {income.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                <span className="text-sm font-normal text-gray-500 ml-1">{baseCurrency}</span>
+              </p>
             </div>
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
               <p className="text-gray-400 text-xs uppercase tracking-wide mb-1">Expenses / mo</p>
-              <p className="text-2xl font-bold text-white">{fmt(expenses)}</p>
+              <p className="text-2xl font-bold text-white tabular-nums">
+                {expenses.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                <span className="text-sm font-normal text-gray-500 ml-1">{baseCurrency}</span>
+              </p>
             </div>
             <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
               <p className="text-gray-400 text-xs uppercase tracking-wide mb-1">Savings / mo</p>
-              <p className="text-2xl font-bold text-white">{fmt(savings)}</p>
+              <p className="text-2xl font-bold text-white tabular-nums">
+                {savings.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                <span className="text-sm font-normal text-gray-500 ml-1">{baseCurrency}</span>
+              </p>
               {savingsRate !== null && (
                 <p className="text-xs text-gray-500 mt-1">{savingsRate.toFixed(1)}% of income</p>
               )}
@@ -309,8 +318,9 @@ export function DashboardPage() {
               surplus < 0 ? 'border-red-800' : 'border-gray-800'
             }`}>
               <p className="text-gray-400 text-xs uppercase tracking-wide mb-1">Surplus / mo</p>
-              <p className={`text-2xl font-bold ${surplus < 0 ? 'text-red-400' : 'text-green-400'}`}>
-                {fmt(surplus)}
+              <p className={`text-2xl font-bold tabular-nums ${surplus < 0 ? 'text-red-400' : 'text-green-400'}`}>
+                {surplus.toLocaleString('en', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                <span className="text-sm font-normal text-gray-500 ml-1">{baseCurrency}</span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Stale net income**: `getJobMonthlyIncome()` was returning the old `netAmount` from DB for all DK salary records whose `deductionsSource` was reset to `NULL` by the `payslip_lines` migration. Added `resolveCalculatedNet()` helper that recalculates net on-the-fly via `calcDanishDeductions()` when a TaxCardSettings is effective at the reference date — fixing income figures on the household page, Sankey diagram, and income summary.
- **Tile layout wrap**: The 4 household summary tiles (Income/mo, Expenses/mo, Savings/mo, Surplus/mo) were rendering the full `fmt()` string (e.g. `"87,435.00 DKK"`) inside a `text-2xl font-bold` paragraph, causing the currency code to wrap onto its own oversized line. Now renders the number in large bold with `tabular-nums` and the currency code as a small muted inline `<span>`.

## Test plan

- [ ] DK job with TaxCardSettings and a pre-migration SalaryRecord (`deductionsSource IS NULL`): household page shows correct calculated net, not the old stored value
- [ ] Non-DK job or DK job with no TaxCardSettings: stored `netAmount` is still used unchanged
- [ ] Sankey income flow diagram reflects the corrected net income values
- [ ] Summary tiles display numbers inline with a small currency label — no wrapping at typical viewport widths
- [ ] Savings rate sub-label still appears below the Savings tile

https://claude.ai/code/session_01RBKPknNX7d9UufoDTJ7yag