### PR TITLE
fix(docker): remove packages/shared COPY from Dockerfile.api

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -7,7 +7,6 @@ RUN apk add --no-cache openssl
 # Install dependencies (includes devDeps — ts-node needed for seed)
 COPY package*.json ./
 COPY apps/api/package*.json ./apps/api/
-COPY packages/shared/package*.json ./packages/shared/
 RUN npm install
 
 # Copy source
@@ -15,7 +14,6 @@ COPY tsconfig.json ./
 COPY prisma.config.ts ./
 COPY prisma ./prisma
 COPY apps/api ./apps/api
-COPY packages/shared ./packages/shared
 
 # Generate Prisma client and build API
 RUN npm run db:generate


### PR DESCRIPTION
## Summary

- Fixes the Docker build failure introduced when `packages/shared` was deleted in the cleanup commit
- `Dockerfile.api` still had two `COPY packages/shared` lines that referenced the now-deleted directory

## Root cause

The cleanup commit removed `packages/shared/` but didn't update `docker/Dockerfile.api`, which copied that directory during the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)