### PR TITLE
fix: use net-based share for household Sankey node values (VIZ-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.55.2] - 2026-04-13 — Fix household Sankey net pay
+
+### Fixed
+- **Household dashboard Sankey node values now show correct net pay** — outgoing link values were previously split using gross-based `sharePct`, so members with different effective tax rates showed inflated or deflated node widths/labels; replaced with a net-based share (`monthlyAllocatedNet / totalMonthlyNet`) so each member node's D3 value exactly equals their actual allocated net income
+
+---
+
 ## [0.55.1] - 2026-04-12 — README overhaul
 
 ### Changed

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -219,13 +219,13 @@ export function DashboardPage() {
     ]
     const links: SankeyLinkDef[] = []
     for (const m of activeMembers) {
-      const share = parseFloat(m.sharePct) / 100
+      const netShare = income > 0 ? parseFloat(m.monthlyAllocatedNet) / income : 0
       for (const c of summary.expenses.byCategory) {
-        const val = parseFloat(c.totalMonthly) * share
+        const val = parseFloat(c.totalMonthly) * netShare
         if (val > 0) links.push({ source: `member_${m.userId}`, target: `cat_${c.categoryId}`, value: val })
       }
-      if (savings > 0) links.push({ source: `member_${m.userId}`, target: 'savings', value: savings * share })
-      if (surplus > 0) links.push({ source: `member_${m.userId}`, target: 'surplus', value: surplus * share })
+      if (savings > 0) links.push({ source: `member_${m.userId}`, target: 'savings', value: savings * netShare })
+      if (surplus > 0) links.push({ source: `member_${m.userId}`, target: 'surplus', value: surplus * netShare })
     }
     return { nodes, links }
   }, [summary, income, savings, surplus])


### PR DESCRIPTION
Member node widths/labels in the household Sankey were computed from
gross-based sharePct, so members with different effective tax rates
showed incorrect net pay amounts. Replace with each member's actual
monthlyAllocatedNet divided by totalMonthlyNet so D3's node.value
equals their real allocated net income.

https://claude.ai/code/session_01DQpcA7nRCu4hoj5v7Bv1Rm